### PR TITLE
hotfix

### DIFF
--- a/data_access_service/core/api.py
+++ b/data_access_service/core/api.py
@@ -86,6 +86,9 @@ class BaseAPI:
     ) -> Coordinate | None:
 
         if data is not None:
+            mapped_col = self.map_column_names(uuid, key, [column])
+            if mapped_col is None or len(mapped_col) == 0:
+                return None
             # Translate to the correct column name for dataset
             mapped_col = self.map_column_names(uuid, key, [column])[0]
             val = data.get(mapped_col)


### PR DESCRIPTION
cloud optimized adds a new dataset today, which is `aggregated_amsa_nonqc.parquet`. it uses h3 to instead decimal lat lon, so will throw an error. This hotfix is to avoid that error