### PR TITLE
add field mapping in routes_helper.py

### DIFF
--- a/data_access_service/utils/routes_helper.py
+++ b/data_access_service/utils/routes_helper.py
@@ -103,6 +103,11 @@ def _generate_partial_json_array(
                 )
             elif "JULD" in record:
                 filtered_record[STR_TIME_LOWER_CASE] = _reformat_date(record["JULD"])
+            # add this for data-uplift aggregated datasets for co-index
+            elif "eventDate" in record:
+                filtered_record[STR_TIME_LOWER_CASE] = _reformat_date(
+                    record["eventDate"]
+                )
             elif "timestamp" in record:
                 filtered_record[STR_TIME_LOWER_CASE] = _reformat_date(
                     datetime.fromtimestamp(
@@ -142,6 +147,12 @@ def _generate_partial_json_array(
                     if record["lon"] is not None
                     else None
                 )
+            elif "decimalLongitude" in record:
+                filtered_record[STR_LONGITUDE_LOWER_CASE] = (
+                    round(record["decimalLongitude"], COORDINATE_INDEX_PRECISION)
+                    if record["decimalLongitude"] is not None
+                    else None
+                )
 
             if "LATITUDE" in record:
                 filtered_record[STR_LATITUDE_LOWER_CASE] = (
@@ -159,6 +170,13 @@ def _generate_partial_json_array(
                 filtered_record[STR_LATITUDE_LOWER_CASE] = (
                     round(record["lat"], COORDINATE_INDEX_PRECISION)
                     if record["lat"] is not None
+                    else None
+                )
+            # add this for data-uplift aggregated datasets for co-index
+            elif "decimalLatitude" in record:
+                filtered_record[STR_LATITUDE_LOWER_CASE] = (
+                    round(record["decimalLatitude"], COORDINATE_INDEX_PRECISION)
+                    if record["decimalLatitude"] is not None
                     else None
                 )
 

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -165,8 +165,8 @@ class TestApi(unittest.TestCase):
             [
                 {
                     "time": "2016-02-07",
-                    "longitude": 147.12346,
-                    "latitude": -42.98765,
+                    "longitude": 147.1,
+                    "latitude": -43.0,
                 }
             ],
         )

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -145,6 +145,32 @@ class TestApi(unittest.TestCase):
         assert parsed_result[1]["longitude"] is None, "LONGITUDE NaN should be None"
         assert parsed_result[1]["depth"] is None, "DEPTH NaN should be None"
 
+    def test_generate_partial_json_array_maps_darwin_core_fields(self):
+        # test generate partial json array with normalised name field
+        df = ddf.from_pandas(
+            pd.DataFrame(
+                {
+                    "eventDate": ["2016-02-07"],
+                    "decimalLongitude": [147.123456],
+                    "decimalLatitude": [-42.987654],
+                }
+            ),
+            npartitions=1,
+        )
+
+        result = list(_generate_partial_json_array(df, None))
+
+        self.assertEqual(
+            result,
+            [
+                {
+                    "time": "2016-02-07",
+                    "longitude": 147.12346,
+                    "latitude": -42.98765,
+                }
+            ],
+        )
+
     def test_normalize_lon(self):
         """Test None"""
         self.assertEqual(BaseAPI.normalize_lon(None), None)


### PR DESCRIPTION
we need update mapping here to get data: http://localhost:5000/api/v1/das/data/ec2c0ef9-3645-4ded-b617-c8297f6eb250/aggregated_seabird_nonqc.parquet?f=sse/json&start_date=2016-02-07&end_date=2016-02-09T23:59:59.999999999&columns=TIME&columns=LONGITUDE&columns=LATITUDE
<img width="637" height="485" alt="image" src="https://github.com/user-attachments/assets/035030a0-aa16-4c40-ab75-c0acd11f23b3" />

Otherwise it will be empty:
<img width="859" height="320" alt="image" src="https://github.com/user-attachments/assets/c10948f3-061d-4721-8cf7-641311ecd3ae" />
