### PR TITLE
Fix api report future date

### DIFF
--- a/data_access_service/core/api.py
+++ b/data_access_service/core/api.py
@@ -1,4 +1,3 @@
-from data_access_service import Config
 import asyncio
 import gzip
 import math
@@ -12,13 +11,14 @@ import secrets
 
 
 from concurrent.futures import ThreadPoolExecutor
+from data_access_service import Config
 
 import dask.dataframe as ddf
 import pandas as pd
 import logging
 import xarray
 
-from datetime import timedelta, timezone
+from datetime import timedelta, timezone, date as dt_date
 from io import BytesIO
 from typing import Optional, Dict, Any, List, Tuple, Hashable
 from aodn_cloud_optimised.lib import DataQuery
@@ -714,6 +714,10 @@ class API(BaseAPI):
                 )
 
             if end_date is not None:
+                # Some dataset has future date
+                if end_date > dt_date.today():
+                    end_date = dt_date.today()
+
                 end_date = end_date.replace(
                     hour=23, minute=59, second=59, microsecond=999999, nanosecond=999
                 )

--- a/data_access_service/core/api.py
+++ b/data_access_service/core/api.py
@@ -18,7 +18,7 @@ import pandas as pd
 import logging
 import xarray
 
-from datetime import timedelta, timezone, date as dt_date
+from datetime import timedelta, timezone
 from io import BytesIO
 from typing import Optional, Dict, Any, List, Tuple, Hashable
 from aodn_cloud_optimised.lib import DataQuery
@@ -714,13 +714,19 @@ class API(BaseAPI):
                 )
 
             if end_date is not None:
-                # Some dataset has future date
-                if end_date > dt_date.today():
-                    end_date = dt_date.today()
+                # Some dataset has future date, we need to do a safety check
+                if end_date.tzinfo is None:
+                    now_compare = pd.Timestamp.now()
+                else:
+                    now_compare = pd.Timestamp.now(tz="UTC")
+                    end_date = end_date.tz_convert("UTC")
 
                 end_date = end_date.replace(
                     hour=23, minute=59, second=59, microsecond=999999, nanosecond=999
                 )
+
+                if end_date > now_compare:
+                    end_date = now_compare
             return start_date, end_date
         else:
             return None, None

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -426,3 +426,63 @@ class TestApi(unittest.TestCase):
 
             # WSSH: both NaN, so empty
             self.assertEqual(len(result["properties"]["WSSH"]), 0)
+
+    def test_get_temporal_extent_future_and_past_dates(self):
+        api = API()
+        uuid = "test-uuid"
+        key = "test-key"
+
+        mock_descriptor = MagicMock()
+        mock_descriptor.dname = "test-dname"
+        api._cached_metadata = {uuid: {key: mock_descriptor}}
+
+        mock_ds = MagicMock()
+        api._instance = MagicMock()
+        api._instance.get_dataset.return_value = mock_ds
+
+        # Case A: Naive end_date in the future
+        future_naive = pd.Timestamp.now() + pd.Timedelta(days=5)
+        start_naive = pd.Timestamp("2020-01-01 12:00:00")
+        mock_ds.get_temporal_extent.return_value = (start_naive, future_naive)
+
+        start_res, end_res = api.get_temporal_extent(uuid, key)
+        self.assertEqual(start_res, pd.Timestamp("2020-01-01 00:00:00"))
+        self.assertIsNotNone(end_res)
+        self.assertLessEqual(end_res, pd.Timestamp.now())
+        self.assertIsNone(end_res.tzinfo)
+
+        # Case B: Aware end_date in the future
+        future_aware = pd.Timestamp.now(tz="UTC") + pd.Timedelta(days=5)
+        start_aware = pd.Timestamp("2020-01-01 12:00:00", tz="UTC")
+        mock_ds.get_temporal_extent.return_value = (start_aware, future_aware)
+
+        start_res, end_res = api.get_temporal_extent(uuid, key)
+        self.assertEqual(start_res, pd.Timestamp("2020-01-01 00:00:00", tz="UTC"))
+        self.assertIsNotNone(end_res)
+        self.assertLessEqual(end_res, pd.Timestamp.now(tz="UTC"))
+        self.assertIsNotNone(end_res.tzinfo)
+
+        # Case C: Naive end_date in the past
+        past_naive = pd.Timestamp.now() - pd.Timedelta(days=5)
+        mock_ds.get_temporal_extent.return_value = (start_naive, past_naive)
+
+        start_res, end_res = api.get_temporal_extent(uuid, key)
+        expected_end_naive = past_naive.replace(
+            hour=23, minute=59, second=59, microsecond=999999, nanosecond=999
+        )
+        self.assertEqual(end_res, expected_end_naive)
+
+        # Case D: Aware end_date in the past
+        past_aware = pd.Timestamp.now(tz="UTC") - pd.Timedelta(days=5)
+        mock_ds.get_temporal_extent.return_value = (start_aware, past_aware)
+
+        start_res, end_res = api.get_temporal_extent(uuid, key)
+        expected_end_aware = past_aware.tz_convert("UTC").replace(
+            hour=23, minute=59, second=59, microsecond=999999, nanosecond=999
+        )
+        self.assertEqual(end_res, expected_end_aware)
+
+        # Case E: Cached metadata does not exist
+        start_res, end_res = api.get_temporal_extent("non-existent-uuid", key)
+        self.assertIsNone(start_res)
+        self.assertIsNone(end_res)


### PR DESCRIPTION
A dataset report temporal in year 21xx which cause the index to inspect a hundred years of no data, which make the indexing super slow. We will only report end date = today at max 