### PR TITLE
Update to allow progress print before change

### DIFF
--- a/data_access_service/config/config-prod.yaml
+++ b/data_access_service/config/config-prod.yaml
@@ -12,3 +12,4 @@ aws:
 pmtiles:
   config:
     bucket_name: aodnportal-production-data
+    show_progress: False

--- a/data_access_service/config/config.py
+++ b/data_access_service/config/config.py
@@ -222,6 +222,7 @@ class Config:
             threads=pmconfig["threads"],
             fetch_size=pmconfig["fetch_size"],
             bucket_name=pmconfig["bucket_name"],
+            show_progress=pmconfig.get("show_progress", True),
         )
 
     def get_parquets_config(self) -> ParquetsGenerationConfig:

--- a/data_access_service/config/config.yaml
+++ b/data_access_service/config/config.yaml
@@ -44,6 +44,8 @@ pmtiles:
     memory_limit: "4G"
     threads: 8
     fetch_size: 50000
+    # Periodic DuckDB query progress logs (via query_progress + Python logger)
+    show_progress: True
   layers:
     hex_z0:
       h3_resolution: 2

--- a/data_access_service/core/duckdbclient.py
+++ b/data_access_service/core/duckdbclient.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import os
 import threading
+import time
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from contextlib import contextmanager
 from tempfile import TemporaryDirectory
 from threading import Lock
-from typing import Any
+from typing import Any, Iterator
 
 import boto3
 import duckdb
@@ -22,6 +24,9 @@ from tenacity import (
     wait_exponential,
     retry_if_exception_type,
 )
+
+# How often to emit a progress log line while a long query is running.
+_PROGRESS_LOG_INTERVAL_SECONDS = 60
 
 
 class DuckDBClient(ABC):
@@ -68,7 +73,7 @@ class PmTileDuckDBClient(DuckDBClient):
         next_wait_seconds = retry_state.next_action.sleep
         next_wait_minutes = round(next_wait_seconds / 60, 1)
 
-        self.logger.warning(
+        self._logger.warning(
             f"[Retry Alert] DuckDB S3 read failed on attempt #{attempt_num}.\n"
             f"Error details: {exception_thrown}\n"
             f"Waiting {next_wait_minutes} minute(s) before attempt #{attempt_num + 1}..."
@@ -76,6 +81,7 @@ class PmTileDuckDBClient(DuckDBClient):
 
     def __init__(self):
         self._config: PmtilesGenerationConfig = Config.get_config().get_pmtiles_config()
+        self._logger = Config.get_config().get_logger()
         self._duckdb_client = None
         self._con = self.get_instance()
         self._lock = Lock()
@@ -122,18 +128,22 @@ class PmTileDuckDBClient(DuckDBClient):
 
                     db.execute("INSTALL httpfs; LOAD httpfs;")
                     db.execute("INSTALL h3 FROM community; LOAD h3;")
-                    db.execute("SET enable_progress_bar = true;")
-                    db.execute("SET enable_progress_bar_print = true;")
 
                     PmTileDuckDBClient._global_db_connection = db
 
-        # CRITICAL: Return a thread-safe, independent cursor from the global connection
+        # CRITICAL: Return a thread-safe, independent cursor from the global connection.
+        # Progress-bar settings are LOCAL scope, so they must be set on this cursor
+        # (not the parent connection). Terminal print is off: DuckDB writes \r bars
+        # to stdout, which never reach uvicorn/app logs. Progress is logged from
+        # execute() via the Python logger instead.
         if self._duckdb_client is None:
             with self._lock:
                 if self._duckdb_client is None:
-                    self._duckdb_client = (
-                        PmTileDuckDBClient._global_db_connection.cursor()
-                    )
+                    cursor = PmTileDuckDBClient._global_db_connection.cursor()
+                    show = bool(self._config.show_progress)
+                    cursor.execute(f"SET enable_progress_bar = {show};")
+                    cursor.execute(f"SET enable_progress_bar_print = {show};")
+                    self._duckdb_client = cursor
         return self._duckdb_client
 
     def close(self):
@@ -179,9 +189,62 @@ class PmTileDuckDBClient(DuckDBClient):
     def execute(
         self, sql: str, params: Sequence[Any] | None = None
     ) -> duckdb.DuckDBPyConnection:
-        if params is None:
-            return self._con.execute(sql)
-        return self._con.execute(sql, params)
+        if not self._config.show_progress:
+            if params is None:
+                return self._con.execute(sql)
+            return self._con.execute(sql, params)
+        with self._progress_logger(sql):
+            if params is None:
+                return self._con.execute(sql)
+            return self._con.execute(sql, params)
+
+    @contextmanager
+    def _progress_logger(self, sql: str) -> Iterator[None]:
+        """Periodically log DuckDB query progress while ``sql`` runs.
+
+        Uses :meth:`duckdb.DuckDBPyConnection.query_progress` on a background
+        thread so long ``COPY`` / aggregation queries emit heartbeat lines into
+        the app logger (visible under uvicorn) instead of silent multi-hour waits.
+        """
+        stop = threading.Event()
+        started = time.monotonic()
+        sql_preview = " ".join(sql.split())[:120]
+        connection = self._con
+
+        def _poll() -> None:
+            while not stop.wait(_PROGRESS_LOG_INTERVAL_SECONDS):
+                elapsed = time.monotonic() - started
+                try:
+                    pct = connection.query_progress()
+                except Exception:
+                    pct = -1.0
+                if pct is not None and pct >= 0:
+                    self._logger.info(
+                        "DuckDB query progress: %.1f%% (%.0fs elapsed) — %s",
+                        pct,
+                        elapsed,
+                        sql_preview,
+                    )
+                else:
+                    self._logger.info(
+                        "DuckDB query still running (%.0fs elapsed) — %s",
+                        elapsed,
+                        sql_preview,
+                    )
+
+        poller = threading.Thread(target=_poll, name="duckdb-progress", daemon=True)
+        poller.start()
+        self._logger.info("DuckDB query started — %s", sql_preview)
+        try:
+            yield
+        finally:
+            stop.set()
+            poller.join(timeout=1.0)
+            self._logger.info(
+                "DuckDB query finished (%.1fs) — %s",
+                time.monotonic() - started,
+                sql_preview,
+            )
 
     def detect_time_type(
         self,

--- a/data_access_service/core/duckdbclient.py
+++ b/data_access_service/core/duckdbclient.py
@@ -12,6 +12,7 @@ from typing import Any, Iterator
 
 import boto3
 import duckdb
+import logging
 
 from data_access_service.models.pmtiles_types import (
     ParquetsGenerationConfig,
@@ -81,7 +82,7 @@ class PmTileDuckDBClient(DuckDBClient):
 
     def __init__(self):
         self._config: PmtilesGenerationConfig = Config.get_config().get_pmtiles_config()
-        self._logger = Config.get_config().get_logger()
+        self._logger = logging.getLogger(__name__)
         self._duckdb_client = None
         self._con = self.get_instance()
         self._lock = Lock()

--- a/data_access_service/models/pmtiles_types.py
+++ b/data_access_service/models/pmtiles_types.py
@@ -14,6 +14,7 @@ class PmtilesGenerationConfig:
     bucket_name: str
     threads: int
     fetch_size: int
+    show_progress: bool
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
During duck db sql processing, nothing happens, so it is better to have some log print

<img width="1605" height="118" alt="image" src="https://github.com/user-attachments/assets/8295829a-1fbd-4a1a-b74e-8d2481e8cf7e" />
