### PR TITLE
Bugfix/1636 avoid newrelic log capture

### DIFF
--- a/data_access_service/batch/pmtiles/generator.py
+++ b/data_access_service/batch/pmtiles/generator.py
@@ -27,16 +27,21 @@ class PmtilesGenerationInProgressError(RuntimeError):
 
 
 def generate_pmtiles_for_all_parquets(api: BaseAPI, uuid: str | None = None):
-    """Generate PMTiles for every parquet dataset in its own short-lived process.
+    """Generate PMTiles for every parquet dataset in the catalog.
 
-    Each dataset is handled in a forked child so DuckDB / tippecanoe allocations
-    are returned to the OS when the child exits. Fork (not re-exec) reuses the
-    already-initialized ``api`` via copy-on-write — no metadata reload per
-    dataset. Datasets run sequentially so only one heavy worker is live at a
+    Process isolation is controlled by ``pmtiles.config.use_fork_process``:
+
+    * **True (default):** each dataset runs in a forked child so DuckDB /
+      tippecanoe allocations are returned to the OS when the child exits.
+      Fork (not re-exec) reuses the already-initialized ``api`` via
+      copy-on-write — no metadata reload per dataset. Invariant: the parent
+      must not open ``PmTileDuckDBClient`` before forking; the child creates
+      its own process-global DuckDB connection.
+    * **False:** each dataset runs in the main app process (no ``os.fork``).
+      Useful for local debug or when an APM agent cannot tolerate forking.
+
+    Datasets always run sequentially so only one heavy worker is live at a
     time.
-
-    Invariant: the parent must not open ``PmTileDuckDBClient`` before forking;
-    the child creates its own process-global DuckDB connection.
 
     Args:
         api: Initialized API with metadata loaded.
@@ -73,19 +78,30 @@ def generate_pmtiles_for_all_parquets(api: BaseAPI, uuid: str | None = None):
             len(work),
         )
 
+    use_fork = config.get_pmtiles_config().use_fork_process
+    logger.info(
+        "PMTiles batch process isolation: use_fork_process=%s",
+        use_fork,
+    )
+
     # Drop full raw schemas / non-parquet metadata so the parent (and COW
     # fork children) start each dataset with a smaller baseline RSS.
     api.release_memory_for_pmtiles_batch()
 
     for k, dataset_name in work:
-        ok = _generate_pmtiles_for_parquets_in_subprocess(api, k, dataset_name)
+        if use_fork:
+            ok = _generate_pmtiles_for_parquets_in_subprocess(api, k, dataset_name)
+            after_label = f"after child for {dataset_name}"
+        else:
+            ok = _generate_pmtiles_for_parquets(api, k, dataset_name)
+            after_label = f"after in-process run for {dataset_name}"
         if not ok:
             logger.error(
                 "PMTiles worker failed for uuid=%s dataset=%s",
                 k,
                 dataset_name,
             )
-        log_memory_usage(logger, f"after child for {dataset_name}")
+        log_memory_usage(logger, after_label)
 
 
 def _generate_pmtiles_for_parquets_in_subprocess(

--- a/data_access_service/config/config-dev.yaml
+++ b/data_access_service/config/config-dev.yaml
@@ -12,4 +12,5 @@ aws:
     job_definition: generate-csv-data-file-dev
 pmtiles:
   config:
-    threads: 3
+    threads: 12
+    use_fork_process: False

--- a/data_access_service/config/config-edge.yaml
+++ b/data_access_service/config/config-edge.yaml
@@ -10,3 +10,6 @@ aws:
   batch:
     job_queue: data-access-service-batch-job-queue
     job_definition: data-access-service-batch-job-definition
+pmtiles:
+  config:
+    use_fork_process: False

--- a/data_access_service/config/config-edge.yaml
+++ b/data_access_service/config/config-edge.yaml
@@ -12,4 +12,4 @@ aws:
     job_definition: data-access-service-batch-job-definition
 pmtiles:
   config:
-    use_fork_process: False
+    use_fork_process: True

--- a/data_access_service/config/config.py
+++ b/data_access_service/config/config.py
@@ -245,6 +245,7 @@ class Config:
             bucket_name=bucket_name,
             show_progress=pmconfig.get("show_progress", True),
             time_group_by=time_group_by,
+            use_fork_process=bool(pmconfig.get("use_fork_process", True)),
         )
 
     def get_parquets_config(self) -> ParquetsGenerationConfig:

--- a/data_access_service/config/config.yaml
+++ b/data_access_service/config/config.yaml
@@ -48,6 +48,10 @@ pmtiles:
     show_progress: True
     # Temporal bucket for hexbin counts: "month" (YYYYMM) or "date" (YYYYMMDD).
     time_group_by: date
+    # True: batch PMTiles generation forks one child process per parquet
+    # dataset (reclaims DuckDB/tippecanoe memory on exit). False: run each
+    # dataset in the main app process.
+    use_fork_process: True
   layers:
     hex_z0:
       h3_resolution: 2

--- a/data_access_service/core/duckdbclient.py
+++ b/data_access_service/core/duckdbclient.py
@@ -56,6 +56,31 @@ class DuckDBClient(ABC):
     def close(self) -> None:
         """Release the connection or cursor held by this client."""
 
+    def create_s3_secret(self, bucket: str) -> None:
+        """Create a DuckDB S3 secret scoped to ``bucket`` from boto3 credentials."""
+        boto_session = boto3.Session()
+        creds = boto_session.get_credentials().get_frozen_credentials()
+        region = boto_session.region_name or "ap-southeast-2"
+
+        def lit(value: str) -> str:
+            return "'" + value.replace("'", "''") + "'"
+
+        def ident(name: str) -> str:
+            return '"' + name.replace('"', '""') + '"'
+
+        self.execute(
+            f"""
+            CREATE OR REPLACE SECRET {ident(f"{bucket}_s3")} (
+                TYPE S3,
+                KEY_ID {lit(creds.access_key)},
+                SECRET {lit(creds.secret_key)},
+                SESSION_TOKEN {lit(creds.token or "")},
+                REGION {lit(region)},
+                SCOPE 's3://{bucket}'
+            )
+            """
+        )
+
 
 class PmTileDuckDBClient(DuckDBClient):
     # Process-global singletons
@@ -145,6 +170,8 @@ class PmTileDuckDBClient(DuckDBClient):
                     cursor.execute(f"SET enable_progress_bar = {show};")
                     cursor.execute(f"SET enable_progress_bar_print = {show};")
                     self._duckdb_client = cursor
+                    # Avoid NewRelic capture the log which is too huge and unless
+                    self.create_s3_secret(self._config.bucket_name)
         return self._duckdb_client
 
     def close(self):
@@ -260,7 +287,7 @@ class PmTileDuckDBClient(DuckDBClient):
         stop = threading.Event()
         started = time.monotonic()
         sql_preview = " ".join(sql.split())[:120]
-        connection = self._con
+        connection = self._duckdb_client
 
         def _poll() -> None:
             while not stop.wait(_PROGRESS_LOG_INTERVAL_SECONDS):
@@ -451,31 +478,6 @@ class ParquetDuckDBClient(DuckDBClient):
         finally:
             with self._cursors_lock:
                 self._active_cursors.discard(cursor)
-
-    def create_s3_secret(self, bucket: str) -> None:
-        """Create a DuckDB S3 secret scoped to ``bucket`` from boto3 credentials."""
-        boto_session = boto3.Session()
-        creds = boto_session.get_credentials().get_frozen_credentials()
-        region = boto_session.region_name or "ap-southeast-2"
-
-        def lit(value: str) -> str:
-            return "'" + value.replace("'", "''") + "'"
-
-        def ident(name: str) -> str:
-            return '"' + name.replace('"', '""') + '"'
-
-        self.execute(
-            f"""
-            CREATE OR REPLACE SECRET {ident(f"{bucket}_s3")} (
-                TYPE S3,
-                KEY_ID {lit(creds.access_key)},
-                SECRET {lit(creds.secret_key)},
-                SESSION_TOKEN {lit(creds.token or "")},
-                REGION {lit(region)},
-                SCOPE 's3://{bucket}'
-            )
-        """
-        )
 
     def close(self) -> None:
         """Cancel any in-flight queries, then close the connection.

--- a/data_access_service/core/duckdbclient.py
+++ b/data_access_service/core/duckdbclient.py
@@ -61,7 +61,7 @@ class DuckDBClient(ABC):
         boto_session = boto3.Session()
 
         # Not useful in testing
-        if boto_session is not None:
+        if boto_session is not None and boto_session.get_credentials() is not None:
             creds = boto_session.get_credentials().get_frozen_credentials()
             region = boto_session.region_name or "ap-southeast-2"
 

--- a/data_access_service/core/duckdbclient.py
+++ b/data_access_service/core/duckdbclient.py
@@ -59,27 +59,30 @@ class DuckDBClient(ABC):
     def create_s3_secret(self, bucket: str) -> None:
         """Create a DuckDB S3 secret scoped to ``bucket`` from boto3 credentials."""
         boto_session = boto3.Session()
-        creds = boto_session.get_credentials().get_frozen_credentials()
-        region = boto_session.region_name or "ap-southeast-2"
 
-        def lit(value: str) -> str:
-            return "'" + value.replace("'", "''") + "'"
+        # Not useful in testing
+        if boto_session is not None:
+            creds = boto_session.get_credentials().get_frozen_credentials()
+            region = boto_session.region_name or "ap-southeast-2"
 
-        def ident(name: str) -> str:
-            return '"' + name.replace('"', '""') + '"'
+            def lit(value: str) -> str:
+                return "'" + value.replace("'", "''") + "'"
 
-        self.execute(
-            f"""
-            CREATE OR REPLACE SECRET {ident(f"{bucket}_s3")} (
-                TYPE S3,
-                KEY_ID {lit(creds.access_key)},
-                SECRET {lit(creds.secret_key)},
-                SESSION_TOKEN {lit(creds.token or "")},
-                REGION {lit(region)},
-                SCOPE 's3://{bucket}'
+            def ident(name: str) -> str:
+                return '"' + name.replace('"', '""') + '"'
+
+            self.execute(
+                f"""
+                CREATE OR REPLACE SECRET {ident(f"{bucket}_s3")} (
+                    TYPE S3,
+                    KEY_ID {lit(creds.access_key)},
+                    SECRET {lit(creds.secret_key)},
+                    SESSION_TOKEN {lit(creds.token or "")},
+                    REGION {lit(region)},
+                    SCOPE 's3://{bucket}'
+                )
+                """
             )
-            """
-        )
 
 
 class PmTileDuckDBClient(DuckDBClient):

--- a/data_access_service/core/duckdbclient.py
+++ b/data_access_service/core/duckdbclient.py
@@ -242,12 +242,12 @@ class PmTileDuckDBClient(DuckDBClient):
     ) -> duckdb.DuckDBPyConnection:
         if not self._config.show_progress:
             if params is None:
-                return self._con.execute(sql)
-            return self._con.execute(sql, params)
+                return self._duckdb_client.execute(sql)
+            return self._duckdb_client.execute(sql, params)
         with self._progress_logger(sql):
             if params is None:
-                return self._con.execute(sql)
-            return self._con.execute(sql, params)
+                return self._duckdb_client.execute(sql)
+            return self._duckdb_client.execute(sql, params)
 
     @contextmanager
     def _progress_logger(self, sql: str) -> Iterator[None]:

--- a/data_access_service/models/pmtiles_types.py
+++ b/data_access_service/models/pmtiles_types.py
@@ -53,6 +53,11 @@ class PmtilesGenerationConfig:
     show_progress: bool
     # "month" (YYYYMM) or "date" (YYYYMMDD); default month preserves existing behavior.
     time_group_by: TimeGroupBy = TimeGroupBy.MONTH
+    # When True (default), batch generation forks one short-lived child per
+    # parquet dataset so DuckDB/tippecanoe memory returns to the OS on exit.
+    # When False, each dataset runs in the main process (useful for local
+    # debug or agents that do not tolerate os.fork, e.g. some APM agents).
+    use_fork_process: bool = True
 
 
 @dataclass

--- a/tests/batch/test_pmtiles/test_generator.py
+++ b/tests/batch/test_pmtiles/test_generator.py
@@ -13,8 +13,17 @@ from data_access_service.batch.pmtiles.generator import (
 from data_access_service.models.pmtiles_types import PmtilesVisualizationStyle
 
 
+def _enable_fork(monkeypatch, enabled: bool = True):
+    monkeypatch.setattr(
+        generator.config,
+        "get_pmtiles_config",
+        lambda: MagicMock(use_fork_process=enabled),
+    )
+
+
 class TestBatchProcessIsolation:
     def test_all_parquets_forks_one_child_per_parquet(self, monkeypatch):
+        _enable_fork(monkeypatch, True)
         api = MagicMock()
         api.get_mapped_meta_data.return_value = {
             "uuid-a": {
@@ -44,7 +53,35 @@ class TestBatchProcessIsolation:
             (api, "uuid-b", "b.parquet"),
         ]
 
+    def test_all_parquets_runs_in_process_when_fork_disabled(self, monkeypatch):
+        _enable_fork(monkeypatch, False)
+        api = MagicMock()
+        api.get_mapped_meta_data.return_value = {
+            "uuid-a": {"a.parquet": {}, "notes.txt": {}},
+            "uuid-b": {"b.parquet": {}},
+        }
+        calls = []
+        fork_spy = MagicMock(return_value=True)
+
+        def fake_in_process(passed_api, uuid, dname):
+            calls.append((uuid, dname))
+            return True
+
+        monkeypatch.setattr(
+            generator, "_generate_pmtiles_for_parquets", fake_in_process
+        )
+        monkeypatch.setattr(
+            generator, "_generate_pmtiles_for_parquets_in_subprocess", fork_spy
+        )
+        monkeypatch.setattr(generator, "log_memory_usage", lambda *a, **k: None)
+
+        generate_pmtiles_for_all_parquets(api)
+
+        assert calls == [("uuid-a", "a.parquet"), ("uuid-b", "b.parquet")]
+        fork_spy.assert_not_called()
+
     def test_all_parquets_can_filter_to_single_uuid(self, monkeypatch):
+        _enable_fork(monkeypatch, True)
         api = MagicMock()
         api.get_mapped_meta_data.return_value = {
             "uuid-a": {"a.parquet": {}, "notes.txt": {}},
@@ -67,6 +104,7 @@ class TestBatchProcessIsolation:
         api.release_memory_for_pmtiles_batch.assert_called_once()
 
     def test_all_parquets_uuid_filter_no_match_skips_workers(self, monkeypatch):
+        _enable_fork(monkeypatch, True)
         api = MagicMock()
         api.get_mapped_meta_data.return_value = {
             "uuid-a": {"a.parquet": {}},
@@ -149,6 +187,7 @@ class TestBatchProcessIsolation:
         )
 
     def test_batch_continues_after_failed_child(self, monkeypatch):
+        _enable_fork(monkeypatch, True)
         api = MagicMock()
         api.get_mapped_meta_data.return_value = {
             "uuid-a": {"a.parquet": {}, "b.parquet": {}},

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -6,3 +6,10 @@ def test_config_trim():
     # Ensure they are loaded and trimmed correctly
     assert config.get_subsetting_bucket_name() == "test-bucket"
     assert config.get_wave_buoy_backup_bucket_name() == "test-wave-buoy-backup-bucket"
+
+
+def test_pmtiles_use_fork_process_default():
+    config = Config.get_config(EnvType.TESTING)
+    pm = config.get_pmtiles_config()
+    # Base config.yaml defaults to True; tests do not override it.
+    assert pm.use_fork_process is True


### PR DESCRIPTION
1. Apply the same pattern as ParquetDuckDBClient to avoid new Relic capture the log entries
2. Add an option to enable/disable processing using fork process or not, by default we use it. We need to test this in local env before we can switch it off in other env.