### PR TITLE
Fix dayline issue

### DIFF
--- a/data_access_service/utils/multi_polygon_helper.py
+++ b/data_access_service/utils/multi_polygon_helper.py
@@ -1,23 +1,37 @@
 """Turning the user's drawn polygons into the shapes the subset paths use.
 
-The portal sends a GeoJSON MultiPolygon whose parts may overlap. Every consumer
-has to dissolve them the same way first - overlapping parts become one outline,
-so the overlap is counted (queried, downloaded, estimated) once - and this
-module is the single owner of that step, so the parquet and zarr paths cannot
-drift apart.
+The portal sends a GeoJSON MultiPolygon whose parts may overlap, and Mapbox may
+emit longitudes outside [-180, 180] when a selection crosses the dateline.
+Every internal consumer has to:
+
+1. dissolve overlapping parts into one outline (overlap counted once), and
+2. split any part that leaves [-180, 180] into polygons that meet at the
+   dateline with longitudes normalised back into that range,
+
+so the parquet, zarr, and size-estimate paths cannot drift apart. This module
+is the single owner of those steps. Email display keeps the original request
+geometry and does not go through this normalisation.
 """
+
+import math
 
 import geojson
 
 from typing import List, Optional, Union
 from geojson import MultiPolygon, Polygon
+from shapely.affinity import translate
 from shapely.geometry import MultiPolygon as ShapelyMultiPolygon
 from shapely.geometry import Polygon as ShapelyPolygon
+from shapely.geometry import box as shapely_box
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import unary_union
 
 from data_access_service.models.bounding_box import BoundingBox
 from data_access_service.models.subset_request import NON_SPECIFIED
+
+# Unit longitude/latitude window used when cutting unwrapped geometries back
+# into the range dataset lon axes and point-in-polygon filters expect.
+_WORLD_BOUNDS = shapely_box(-180.0, -90.0, 180.0, 90.0)
 
 
 def get_bbox_from(polygon: Polygon) -> BoundingBox:
@@ -64,6 +78,9 @@ def merge_polygons(
 
     Overlapping parts merge into one outline (their overlap is then counted
     once); disjoint parts stay separate. Holes drawn by the user are kept.
+    Parts that leave [-180, 180] (Mapbox dateline wraps) are then split into
+    polygons that meet at the dateline with longitudes in that range — works
+    for both axis-aligned boxes and freeform rings.
 
     Returns [] when there is no spatial filter (or the MultiPolygon has no
     parts) - the caller decides what that means.
@@ -84,16 +101,55 @@ def merge_polygons(
         # e.g. every part is a zero-area sliver. Returning [] here would be read
         # as "no spatial filter" and silently subset the whole globe.
         raise ValueError(f"multi_polygon encloses no area: {parsed}")
-    return merged
+
+    # Dissolve first (unwrapped coords are fine for planar union), then cut
+    # anything that still sits outside [-180, 180] into dateline-safe pieces.
+    split: List[ShapelyPolygon] = []
+    for polygon in merged:
+        split.extend(split_at_dateline(polygon))
+    if not split:
+        raise ValueError(f"multi_polygon encloses no area: {parsed}")
+    return split
+
+
+def split_at_dateline(geometry: BaseGeometry) -> List[ShapelyPolygon]:
+    """Cut a polygon into pieces whose longitudes all lie in [-180, 180].
+
+    Mapbox may send a continuous ring with lon &lt; -180 or lon &gt; 180 when the
+    user selects across the antimeridian. Vertex-only wrapping is wrong (it
+    invents a near-global strip). Instead, keep the unwrapped shape, slide it
+    by multiples of 360°, and intersect each copy with the unit world window.
+    Rectangles become two boxes that meet at ±180; freeform rings become two
+    freeform pieces with a cut on the dateline. Already-normal geometry is
+    returned unchanged.
+    """
+    if geometry is None or geometry.is_empty:
+        return []
+
+    min_lon, _min_lat, max_lon, _max_lat = geometry.bounds
+    if min_lon >= -180.0 and max_lon <= 180.0:
+        return to_polygons(geometry)
+
+    # Window k covers lon in [-180 + 360k, 180 + 360k]. Every unwrapped bound
+    # falls in at least one such window; empty intersections are dropped below.
+    k_min = math.floor((min_lon + 180.0) / 360.0)
+    k_max = math.floor((max_lon + 180.0) / 360.0)
+
+    pieces: List[ShapelyPolygon] = []
+    for k in range(int(k_min), int(k_max) + 1):
+        shifted = translate(geometry, xoff=-360.0 * k)
+        clipped = shifted.intersection(_WORLD_BOUNDS)
+        pieces.extend(to_polygons(clipped))
+    return pieces
 
 
 def to_polygons(geometry: BaseGeometry) -> List[ShapelyPolygon]:
-    """Flatten a unary_union result into a plain list of polygons with area.
+    """Flatten a unary_union / intersection result into polygons with area.
 
-    unary_union returns a Polygon, a MultiPolygon, or - when the parts include
-    degenerate geometry - a GeometryCollection mixing lines/points in. Anything
-    without area is dropped: it selects no cell to subset, and a zero-width
-    bounding box is rejected by BoundingBox anyway.
+    unary_union and intersection return a Polygon, a MultiPolygon, or - when
+    the parts include degenerate geometry - a GeometryCollection mixing
+    lines/points in. Anything without area is dropped: it selects no cell to
+    subset, and a zero-width bounding box is rejected by BoundingBox anyway.
     """
     if isinstance(geometry, ShapelyPolygon):
         return [geometry] if geometry.area > 0 else []

--- a/tests/batch/subsetting/tasks/test_zarr_processor.py
+++ b/tests/batch/subsetting/tasks/test_zarr_processor.py
@@ -311,6 +311,90 @@ class TestSubsetZarr(TestWithS3):
                 finally:
                     shutil.rmtree(config.get_temp_folder("888"), ignore_errors=True)
 
+    @patch("aodn_cloud_optimised.lib.DataQuery.REGION", REGION)
+    def test_zarr_mapbox_unwrapped_dateline_matches_normalised(
+        self,
+        aws_clients,
+        upload_test_case_to_s3,
+        mock_get_fs_token_paths,
+        subset_request_factory,
+    ):
+        """#8210 end to end: Mapbox unwrapped lon outside [-180, 180].
+
+        Portal/Mapbox can send a continuous box that crosses the antimeridian
+        with lon < -180. That must be split into dateline-safe pieces and yield
+        the same NetCDF as the already-normal MultiPolygon of those pieces —
+        not an empty lon axis (raw unwrapped bbox misses the store) and not a
+        near-global strip from wrapping vertices alone.
+        """
+        config = Config.get_config()
+        helper = AWSHelper()
+
+        api = API()
+        api.initialize_metadata()
+
+        # Continuous unwrapped box across the dateline. West side after the
+        # split is the Tasman Sea (RAMSSA canned store has real SST there).
+        unwrapped = (-210.0, -40.0, -150.0, -38.0)
+        west = (150.0, -40.0, 180.0, -38.0)
+        east = (-180.0, -40.0, -150.0, -38.0)
+
+        no_ext_key = RAMSSA_KEY.replace(".zarr", "")
+        out_key = f"job_id_888/{no_ext_key}.nc"
+
+        def _download(multi_polygon: str) -> xarray.Dataset:
+            ZarrProcessor(
+                api,
+                job_id="job_id_888",
+                subset_request=subset_request_factory(
+                    uuid=RAMSSA_UUID,
+                    keys=[RAMSSA_KEY],
+                    start_date="2011-11-17",
+                    end_date="2011-11-17",
+                    multi_polygon=multi_polygon,
+                ),
+            ).process()
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                temp_file_path = Path(tmpdirname) / f"{no_ext_key}.nc"
+                helper.download_file_from_s3(
+                    config.get_subsetting_bucket_name(),
+                    out_key,
+                    str(temp_file_path),
+                )
+                # Load into memory so the temp file can be removed.
+                return xarray.open_dataset(temp_file_path).load()
+
+        with patch("fsspec.core.get_fs_token_paths", mock_get_fs_token_paths):
+            with patch.object(AWSHelper, "send_email"):
+                try:
+                    from_unwrapped = _download(_multi_polygon_of(unwrapped))
+                    from_normalised = _download(_multi_polygon_of(west, east))
+
+                    assert from_unwrapped.sizes["lon"] > 0, (
+                        "unwrapped dateline box produced empty lon axis "
+                        "(coords were not split back into [-180, 180])"
+                    )
+                    assert from_unwrapped.sizes == from_normalised.sizes
+                    np.testing.assert_allclose(
+                        from_unwrapped["lat"].values, from_normalised["lat"].values
+                    )
+                    np.testing.assert_allclose(
+                        from_unwrapped["lon"].values, from_normalised["lon"].values
+                    )
+                    np.testing.assert_allclose(
+                        from_unwrapped["analysed_sst"].values,
+                        from_normalised["analysed_sst"].values,
+                        equal_nan=True,
+                    )
+
+                    lons = from_unwrapped["lon"].values
+                    assert lons.min() >= -180.0 and lons.max() <= 180.0
+                    # Australian / Tasman side of the split must be present.
+                    assert ((lons >= 150.0) & (lons <= 180.0)).any()
+                    assert np.isfinite(from_unwrapped["analysed_sst"].values).any()
+                finally:
+                    shutil.rmtree(config.get_temp_folder("888"), ignore_errors=True)
+
     def test_non_specified_multi_polygon(
         self,
         aws_clients,

--- a/tests/utils/test_multi_polygon_helper.py
+++ b/tests/utils/test_multi_polygon_helper.py
@@ -1,11 +1,13 @@
 import geojson
 import pytest
 from shapely.geometry import Point as ShapelyPoint
+from shapely.geometry import Polygon as ShapelyPolygon
 
 from data_access_service.utils.multi_polygon_helper import (
     MultiPolygonHelper,
     merge_polygons,
     parse_multi_polygon,
+    split_at_dateline,
 )
 
 
@@ -99,6 +101,126 @@ class TestMergePolygons:
             merge_polygons(collapsed)
 
 
+class TestSplitAtDateline:
+    def test_already_in_range_is_unchanged(self):
+        poly = ShapelyPolygon(_rect(10, 0, 20, 10))
+        pieces = split_at_dateline(poly)
+
+        assert len(pieces) == 1
+        assert pieces[0].equals(poly)
+
+    def test_mapbox_unwrapped_rectangle_splits_at_dateline(self):
+        # Portal/Mapbox example: continuous box with lon < -180 that crosses
+        # the antimeridian. Must become two boxes that meet at ±180, not a
+        # single bogus strip from wrapping vertices alone.
+        lon_min, lon_max = -212.67488435641027, -157.75735934215612
+        lat_min, lat_max = -39.90820956224461, -9.159204863042774
+        poly = ShapelyPolygon(_rect(lon_min, lat_min, lon_max, lat_max))
+
+        pieces = split_at_dateline(poly)
+        bounds = sorted(p.bounds for p in pieces)
+
+        assert len(pieces) == 2
+        west = (lon_min + 360, lat_min, 180.0, lat_max)
+        east = (-180.0, lat_min, lon_max, lat_max)
+        assert bounds[0] == pytest.approx(east)
+        assert bounds[1] == pytest.approx(west)
+        assert sum(p.area for p in pieces) == pytest.approx(poly.area)
+        for piece in pieces:
+            min_lon, _, max_lon, _ = piece.bounds
+            assert -180.0 <= min_lon <= max_lon <= 180.0
+
+    def test_lon_above_180_splits_at_dateline(self):
+        poly = ShapelyPolygon(_rect(170, -10, 200, 10))
+        pieces = split_at_dateline(poly)
+        bounds = sorted(p.bounds for p in pieces)
+
+        assert len(pieces) == 2
+        assert bounds[0] == pytest.approx((-180.0, -10, -160.0, 10))
+        assert bounds[1] == pytest.approx((170.0, -10, 180.0, 10))
+
+    def test_freeform_unwrapped_crossing_dateline(self):
+        # Triangle with one vertex west of the dateline in unwrapped space.
+        ring = [
+            [-200.0, 0.0],
+            [-160.0, 0.0],
+            [-180.0, 20.0],
+            [-200.0, 0.0],
+        ]
+        poly = ShapelyPolygon(ring)
+        pieces = split_at_dateline(poly)
+
+        assert len(pieces) >= 2
+        assert sum(p.area for p in pieces) == pytest.approx(poly.area)
+        # A point known inside the original on each side of -180.
+        west_point = ShapelyPoint(-190.0, 2.0)  # unwraps to lon 170
+        east_point = ShapelyPoint(-170.0, 2.0)
+        assert poly.contains(west_point) and poly.contains(east_point)
+        covered = ShapelyPolygon()
+        for piece in pieces:
+            min_lon, _, max_lon, _ = piece.bounds
+            assert -180.0 <= min_lon <= max_lon <= 180.0
+            covered = covered.union(piece)
+        # After wrap: west_point becomes (170, 2); east stays (-170, 2).
+        assert any(p.contains(ShapelyPoint(170.0, 2.0)) for p in pieces)
+        assert any(p.contains(ShapelyPoint(-170.0, 2.0)) for p in pieces)
+
+    def test_hole_on_one_side_is_kept(self):
+        outer = _rect(-200, 0, -160, 20)
+        # Hole entirely east of the dateline in unwrapped space (lon > -180).
+        hole = _rect(-175, 5, -165, 15)
+        poly = ShapelyPolygon(outer, [hole])
+
+        pieces = split_at_dateline(poly)
+        assert sum(p.area for p in pieces) == pytest.approx(poly.area)
+        # The hole centre, once lon is still in range, must stay outside.
+        hole_centre = ShapelyPoint(-170.0, 10.0)
+        assert not any(p.contains(hole_centre) for p in pieces)
+
+
+class TestMergePolygonsDateline:
+    def test_mapbox_rectangle_via_merge_polygons(self):
+        merged = merge_polygons(
+            _multi_polygon(
+                _rect(
+                    -212.67488435641027,
+                    -39.90820956224461,
+                    -157.75735934215612,
+                    -9.159204863042774,
+                )
+            )
+        )
+        assert len(merged) == 2
+        for polygon in merged:
+            min_lon, _, max_lon, _ = polygon.bounds
+            assert -180.0 <= min_lon <= max_lon <= 180.0
+
+    def test_whole_globe_stays_one_polygon(self):
+        merged = merge_polygons(_multi_polygon(_rect(-180, -90, 180, 90)))
+        assert len(merged) == 1
+        assert merged[0].bounds == pytest.approx((-180, -90, 180, 90))
+
+    def test_overlapping_unwrapped_rects_dissolve_then_split(self):
+        # Two overlapping unwrapped boxes that both cross the dateline must
+        # dissolve into one continuous region first, then split into two
+        # pieces — not four shards.
+        merged = merge_polygons(
+            _multi_polygon(
+                _rect(-210, 0, -160, 10),
+                _rect(-200, 0, -150, 10),
+            )
+        )
+        assert len(merged) == 2
+        # Unwrapped union is lon -210..-150 (width 60) x height 10.
+        assert sum(p.area for p in merged) == pytest.approx(600.0)
+
+    def test_freeform_in_range_unchanged(self):
+        ring = [[10, 0], [20, 0], [15, 10], [10, 0]]
+        merged = merge_polygons(_multi_polygon(ring))
+        assert len(merged) == 1
+        assert merged[0].equals(ShapelyPolygon(ring))
+
+
 class TestMultiPolygonHelper:
     def test_no_multi_polygon_means_no_bboxes(self):
         # All three views must agree that no spatial filter was given: [] flows
@@ -167,3 +289,21 @@ class TestMultiPolygonHelper:
                 bbox.max_lon,
                 bbox.max_lat,
             )
+
+    def test_mapbox_dateline_box_yields_two_bboxes_and_multipolygon(self):
+        helper = MultiPolygonHelper(
+            multi_polygon=_multi_polygon(
+                _rect(
+                    -212.67488435641027,
+                    -39.90820956224461,
+                    -157.75735934215612,
+                    -9.159204863042774,
+                )
+            )
+        )
+
+        assert len(helper.bboxes) == 2
+        assert helper.geometry.geom_type == "MultiPolygon"
+        for bbox in helper.bboxes:
+            assert -180.0 <= bbox.min_lon <= bbox.max_lon <= 180.0
+            assert bbox.min_lat < bbox.max_lat


### PR DESCRIPTION
1. When a bounding box or a polygon download that comes from UI, Sometime user choose an area that cross the meridian line. 
2. In Mapbox it handle it by exceeding 180 or -180 that is -200 for example
3. This fix make the geometry split into two and apply filter correctly instead of assume -200 is valid