### PR TITLE
Handle edge case where date overlap in the mid, we should have 1nano …

### DIFF
--- a/data_access_service/batch/subsetting/helpers/parquet_date_ranges.py
+++ b/data_access_service/batch/subsetting/helpers/parquet_date_ranges.py
@@ -156,11 +156,30 @@ def check_rows_with_date_range(
                 }
             )
         else:
-            log.info(f"Splitting range {start} to {end} (rows: {num_rows})")
             try:
-                split_start, split_mid, split_end = split_date_range_binary(start, end)
-                heapq.heappush(q, (split_start, split_mid, times_of_split + 1))
-                heapq.heappush(q, (split_mid, split_end, times_of_split + 1))
+                left_start, left_end, right_start, right_end = split_date_range_binary(
+                    start, end
+                )
+                # Parent is discarded: only the two non-overlapping halves are
+                # re-queued. Log makes that replacement explicit so nested split
+                # lines are not read as re-processing the same parent range.
+                log.info(
+                    "Range too large (%s rows > limit %s); discarding parent "
+                    "[%s → %s] and enqueueing non-overlapping halves "
+                    "[%s → %s] and [%s → %s] (split depth %s → %s)",
+                    num_rows,
+                    PARQUET_SUBSET_ROW_NUMBER,
+                    start,
+                    end,
+                    left_start,
+                    left_end,
+                    right_start,
+                    right_end,
+                    times_of_split,
+                    times_of_split + 1,
+                )
+                heapq.heappush(q, (left_start, left_end, times_of_split + 1))
+                heapq.heappush(q, (right_start, right_end, times_of_split + 1))
 
             except Exception as e:
                 log.warning(f"Could not split range {start} to {end}: {e}")

--- a/data_access_service/utils/date_time_utils.py
+++ b/data_access_service/utils/date_time_utils.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from inspect import iscoroutinefunction
 
 from dateutil.relativedelta import relativedelta
+from pandas._libs import NaTType
 
 from data_access_service.models.subset_request import NON_SPECIFIED
 
@@ -30,8 +31,8 @@ log = logging.getLogger(__name__)
 
 # parse all common format of date string into given format, such as "%Y-%m-%d"
 def parse_date(
-    date_string: str, format_to_convert: str = None, time_zone: str = pytz.UTC
-) -> pd.Timestamp:
+    date_string: str, format_to_convert: str | None = None, time_zone: str = pytz.UTC
+) -> pd.Timestamp | NaTType:
     if format_to_convert is None:
         return pd.Timestamp(date_string).tz_localize(time_zone)
     else:
@@ -96,7 +97,7 @@ def next_month_first_day(date: pd.Timestamp) -> pd.Timestamp:
     )
 
 
-def ensure_timezone(dt: pd.Timestamp) -> pd.Timestamp:
+def ensure_timezone(dt: pd.Timestamp | NaTType) -> pd.Timestamp | NaTType:
     """
     Check if datetime has timezone info; if not, assume UTC.
 
@@ -106,7 +107,7 @@ def ensure_timezone(dt: pd.Timestamp) -> pd.Timestamp:
     Returns:
         Datetime object with timezone info (UTC if none was present)
     """
-    if dt.tz is None:
+    if dt.tz is None and not isinstance(dt, NaTType):
         return dt.tz_localize(pytz.UTC)
     return dt
 
@@ -122,30 +123,68 @@ def to_naive_utc(ts: pd.Timestamp | None) -> pd.Timestamp | None:
 
 def split_date_range_binary(
     start_date: Timestamp, end_date: Timestamp
-) -> tuple[Timestamp, Timestamp, Timestamp]:
+) -> tuple[Timestamp, Timestamp | NaTType, Timestamp | NaTType, Timestamp]:
     """
-    A basic binary division to split date range
+    Binary-split a date range into two adjacent, non-overlapping inclusive halves.
+
+    Filters treat both ends as inclusive, so the split uses a 1ns gap at the mid
+    point: left is [start, mid_exclusive_end] and right is [right_start, end],
+    with mid_exclusive_end + 1ns == right_start. Together they cover [start, end]
+    without sharing any timestamp.
+
     Args:
-        start_date: The start date of the range. UTC string in 'YYYY-MM-DD HH:MM:SS.fffffffff+00:00' format.
-        end_date: The end date of the range. UTC string in 'YYYY-MM-DD HH:MM:SS.fffffffff+00:00' format.
+        start_date: Inclusive start of the range (UTC).
+        end_date: Inclusive end of the range (UTC).
+
     Returns:
-        tuple[str, str, str] The start date, mid date, and end date of the date range.
+        (left_start, left_end, right_start, right_end)
+
+    Raises:
+        ValueError: If the range is too short to split into two non-empty halves.
     """
     if not isinstance(start_date, pd.Timestamp):
         start_date = pd.Timestamp(start_date)
     if not isinstance(end_date, pd.Timestamp):
         end_date = pd.Timestamp(end_date)
 
-    duration_ns = (end_date - start_date).total_seconds() * 1e9
-    mid_ns = duration_ns / 2
-
-    mid_date = start_date + pd.Timedelta(nanoseconds=mid_ns)
-    # make sure the time zone is attached
     start_date = ensure_timezone(start_date)
-    mid_date = ensure_timezone(mid_date)
     end_date = ensure_timezone(end_date)
 
-    return start_date, mid_date, end_date
+    if isinstance(start_date, NaTType):
+        raise ValueError(f"Invalid start_date of type NaTType")
+
+    if isinstance(end_date, NaTType):
+        raise ValueError(f"Invalid end_date of type NaTType")
+
+    if end_date < start_date:
+        raise ValueError(f"Invalid range: end {end_date} is before start {start_date}")
+
+    # Need at least 2 distinct nanosecond ticks so each half is non-empty.
+    # Work in integer nanoseconds so we never hit pandas' Timestamp|NaTType
+    # arithmetic stubs (Timestamp ± Timedelta is typed as possibly NaT).
+    start_ns = int(start_date.value)
+    end_ns = int(end_date.value)
+    duration_ns = end_ns - start_ns
+    if duration_ns < 1:
+        raise ValueError(
+            f"Range too short to split without overlap: {start_date} to {end_date}"
+        )
+
+    # right_start is the first tick of the right half (ceiling of midpoint).
+    mid_offset_ns = (duration_ns + 1) // 2
+    right_start_ns = start_ns + mid_offset_ns
+    left_end_ns = right_start_ns - 1
+    tz = start_date.tz
+
+    right_start = pd.Timestamp(right_start_ns, unit="ns", tz=tz)
+    left_end = pd.Timestamp(left_end_ns, unit="ns", tz=tz)
+
+    if left_end < start_date or right_start > end_date:
+        raise ValueError(
+            f"Range too short to split without overlap: {start_date} to {end_date}"
+        )
+
+    return start_date, left_end, right_start, end_date
 
 
 def get_monthly_utc_date_range_array_from_(

--- a/tests/utils/test_date_time_uils.py
+++ b/tests/utils/test_date_time_uils.py
@@ -1151,14 +1151,32 @@ class TestDateTimeUtils(unittest.TestCase):
         start = ensure_timezone(pd.Timestamp("2010-01-01"))
         end = ensure_timezone(pd.Timestamp("2010-01-03"))
 
-        split_start, split_mid, split_end = split_date_range_binary(start, end)
-        expected_split_start = pd.Timestamp("2010-01-01", tz="UTC")
-        expected_split_mid = pd.Timestamp("2010-01-02", tz="UTC")
-        expected_split_end = pd.Timestamp("2010-01-03", tz="UTC")
-        self.assertEqual(
-            (split_start, split_mid, split_end),
-            (expected_split_start, expected_split_mid, expected_split_end),
+        left_start, left_end, right_start, right_end = split_date_range_binary(
+            start, end
         )
+        expected_left_start = pd.Timestamp("2010-01-01", tz="UTC")
+        # Midpoint of [01-01, 01-03] → right starts at 01-02; left ends 1ns before.
+        expected_right_start = pd.Timestamp("2010-01-02", tz="UTC")
+        expected_left_end = expected_right_start - pd.Timedelta(nanoseconds=1)
+        expected_right_end = pd.Timestamp("2010-01-03", tz="UTC")
+        self.assertEqual(
+            (left_start, left_end, right_start, right_end),
+            (
+                expected_left_start,
+                expected_left_end,
+                expected_right_start,
+                expected_right_end,
+            ),
+        )
+        # Halves are adjacent and non-overlapping (inclusive ends).
+        self.assertEqual(left_end + pd.Timedelta(nanoseconds=1), right_start)
+        self.assertLess(left_end, right_start)
+
+    def test_split_date_range_binary_rejects_too_short_range(self):
+        start = ensure_timezone(pd.Timestamp("2010-01-01 00:00:00"))
+        end = start  # zero-width
+        with self.assertRaises(ValueError):
+            split_date_range_binary(start, end)
 
     @patch(
         "data_access_service.batch.subsetting.helpers.parquet_date_ranges.PARQUET_SUBSET_ROW_NUMBER",
@@ -1202,8 +1220,10 @@ class TestDateTimeUtils(unittest.TestCase):
 
         start_date = mock_date_ranges[0]["start_date"]
         end_date = mock_date_ranges[0]["end_date"]
-        mid_date = datetime(2023, 1, 15, tzinfo=timezone.utc)
-        mock_split.return_value = (start_date, mid_date, end_date)
+        # Non-overlapping halves: left ends 1ns before right starts.
+        right_start = datetime(2023, 1, 15, tzinfo=timezone.utc)
+        left_end = right_start - pd.Timedelta(nanoseconds=1)
+        mock_split.return_value = (start_date, left_end, right_start, end_date)
 
         result = check_rows_with_date_range(
             api=mock_api,
@@ -1217,6 +1237,10 @@ class TestDateTimeUtils(unittest.TestCase):
         self.assertEqual(len(result), 2)
         mock_split.assert_called_once()
         mock_log.info.assert_called_once()
+        # Parent-replacement wording, not a bare "Splitting range".
+        log_msg = mock_log.info.call_args[0][0]
+        self.assertIn("discarding parent", log_msg)
+        self.assertIn("non-overlapping halves", log_msg)
 
     @patch(
         "data_access_service.batch.subsetting.helpers.parquet_date_ranges.PARQUET_SUBSET_ROW_NUMBER",


### PR DESCRIPTION
1. During the date split there is a common time, from log

2026-08-12 07:02:11 - data_access_service.batch.subsetting.helpers.parquet_date_ranges - INFO - Splitting range 2025-03-01 00:00:00+00:00 to 2025-03-16 11:59:59.999999500+00:00 (rows: 205571)

2026-08-12 07:02:12 - data_access_service.batch.subsetting.helpers.parquet_date_ranges - INFO - Splitting range 2025-03-16 11:59:59.999999500+00:00 to 2025-03-31 23:59:59.999999999+00:00 (rows: 206199)

The time is overlap at 2025-03-16 11:59:59.999999500

This fix is to add 1 nanosec to the start time 2025-03-16 11:59:59.999999501 something like that