### PR TITLE
Fix get_temporay_extents to use the right time field name

### DIFF
--- a/data_access_service/config/config.yaml
+++ b/data_access_service/config/config.yaml
@@ -1,4 +1,6 @@
-# Order of values under each key matters, do not change it. Else you will get test errors.
+# Order of values under each key matters, do not change it. For example, _temporal_extent should be before the timestamp.
+# because seagrass dataset has _temporal_extent column, it will be used for time range query, instead of timestamp which
+# is hive column
 column_name_mapping:
   time:
     - TIME
@@ -6,6 +8,7 @@ column_name_mapping:
     - JULD
     - eventDate
     - detection_timestamp
+    - _temporal_extent
     - timestamp
   depth:
   latitude:

--- a/data_access_service/core/api.py
+++ b/data_access_service/core/api.py
@@ -704,13 +704,26 @@ class API(BaseAPI):
     Given a time range, we find if this uuid temporal cover the whole range
     """
 
+    def _source_temporal_extent(
+        self, ds: DataQuery.DataSource, uuid: str, key: str
+    ) -> Tuple[pd.Timestamp, pd.Timestamp]:
+        """Read min/max time from the cloud-optimised source.
+
+        Parquet extent lookup needs the mapped time column (e.g.
+        ``_temporal_extent``). Zarr does not take that argument.
+        """
+        if isinstance(ds, ParquetDataSource):
+            _, _, time_varname = self.resolve_dim_names(uuid, key)
+            return ds.get_temporal_extent(time_varname=time_varname)
+        return ds.get_temporal_extent()
+
     def has_data(
         self, uuid: str, key: str, start_date: pd.Timestamp, end_date: pd.Timestamp
     ):
         md: Dict[str, Descriptor] | None = self._cached_metadata.get(uuid)
         if md is not None and md[key] is not None:
             ds: DataQuery.DataSource = self._instance.get_dataset(md[key].dname)
-            tes, tee = ds.get_temporal_extent()
+            tes, tee = self._source_temporal_extent(ds, uuid, key)
             return start_date <= tes and tee <= end_date
         return False
 
@@ -721,7 +734,7 @@ class API(BaseAPI):
         if md is not None:
             ds: DataQuery.DataSource = self._instance.get_dataset(md[key].dname)
             try:
-                start_date, end_date = ds.get_temporal_extent()
+                start_date, end_date = self._source_temporal_extent(ds, uuid, key)
 
                 if start_date is not None:
                     start_date = start_date.replace(

--- a/data_access_service/core/routes/helpers.py
+++ b/data_access_service/core/routes/helpers.py
@@ -66,8 +66,11 @@ def convert_non_numeric_to_str(df: DataFrame) -> DataFrame:
 
 
 def lazy_to_records_fast(df):
-    for row in df.itertuples(index=False):
-        yield row._asdict()  # Returns an OrderedDict; use dict(row._asdict()) if plain dict needed
+    # name=None keeps column names that are not valid namedtuple fields
+    # (e.g. _temporal_extent). _asdict() would drop those names.
+    columns = df.columns
+    for row in df.itertuples(index=False, name=None):
+        yield dict(zip(columns, row))
 
 
 # Use to remap the field name back to column that we pass it, the raw data itself may name the field differently
@@ -113,6 +116,10 @@ def _generate_partial_json_array(
             elif "eventDate" in record:
                 filtered_record[STR_TIME_LOWER_CASE] = _reformat_date(
                     record["eventDate"]
+                )
+            elif "_temporal_extent" in record:
+                filtered_record[STR_TIME_LOWER_CASE] = _reformat_date(
+                    record["_temporal_extent"]
                 )
             elif "timestamp" in record:
                 filtered_record[STR_TIME_LOWER_CASE] = _reformat_date(

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 from aodn_cloud_optimised.lib import DataQuery
+from aodn_cloud_optimised.lib.DataQuery import ParquetDataSource
 
 from data_access_service import API
 from data_access_service.core.api import BaseAPI
@@ -101,6 +102,28 @@ class TestApi(unittest.TestCase):
                 ["eventDate", "decimalLatitude", "decimalLongitude"],
                 "TIME mapped to eventDate, LATITUDE mapped to decimalLatitude, LONGITUDE mapped to decimalLongitude",
             )
+
+    def test_map_column_names_prefers_temporal_extent_over_timestamp(self):
+        api = API()
+        api._schema_keys = {
+            "u": {
+                "seagrass.parquet": frozenset(
+                    {
+                        "_temporal_extent",
+                        "timestamp",
+                        "decimalLatitude",
+                        "decimalLongitude",
+                    }
+                )
+            }
+        }
+        col = api.map_column_names(
+            "u", "seagrass.parquet", ["TIME", "LATITUDE", "LONGITUDE"]
+        )
+        self.assertListEqual(
+            col,
+            ["_temporal_extent", "decimalLatitude", "decimalLongitude"],
+        )
 
     with open(
         Path(__file__).resolve().parent.parent / "canned/catalog_uncached.json", "r"
@@ -232,6 +255,32 @@ class TestApi(unittest.TestCase):
                     "time": "2016-02-07",
                     "longitude": 147.1,
                     "latitude": -43.0,
+                }
+            ],
+        )
+
+    def test_generate_partial_json_array_maps_temporal_extent(self):
+        df = ddf.from_pandas(
+            pd.DataFrame(
+                {
+                    "_temporal_extent": ["2025-02-23"],
+                    "timestamp": [1735689600],
+                    "decimalLongitude": [147.9],
+                    "decimalLatitude": [-40.3],
+                }
+            ),
+            npartitions=1,
+        )
+
+        result = list(_generate_partial_json_array(df, None))
+
+        self.assertEqual(
+            result,
+            [
+                {
+                    "time": "2025-02-23",
+                    "longitude": 147.9,
+                    "latitude": -40.3,
                 }
             ],
         )
@@ -455,3 +504,38 @@ class TestApi(unittest.TestCase):
         start_res, end_res = api.get_temporal_extent("non-existent-uuid", key)
         self.assertIsNone(start_res)
         self.assertIsNone(end_res)
+
+    def test_get_temporal_extent_passes_mapped_time_varname_for_parquet(self):
+        api = API()
+        uuid = "test-uuid"
+        key = "test-key"
+
+        mock_descriptor = MagicMock()
+        mock_descriptor.dname = "test-dname"
+        api._cached_metadata = {uuid: {key: mock_descriptor}}
+        api.resolve_dim_names = MagicMock(return_value=(None, None, "_temporal_extent"))
+
+        class _FakeParquet(ParquetDataSource):
+            def __init__(self):
+                pass
+
+        mock_ds = _FakeParquet.__new__(_FakeParquet)
+        mock_ds.get_temporal_extent = MagicMock(
+            return_value=(
+                pd.Timestamp("2025-02-23 12:00:00"),
+                pd.Timestamp("2025-02-23 12:00:00"),
+            )
+        )
+        api._instance = MagicMock()
+        api._instance.get_dataset.return_value = mock_ds
+
+        start_res, end_res = api.get_temporal_extent(uuid, key)
+
+        mock_ds.get_temporal_extent.assert_called_once_with(
+            time_varname="_temporal_extent"
+        )
+        self.assertEqual(start_res, pd.Timestamp("2025-02-23 00:00:00"))
+        expected_end = pd.Timestamp("2025-02-23 12:00:00").replace(
+            hour=23, minute=59, second=59, microsecond=999999, nanosecond=999
+        )
+        self.assertEqual(end_res, expected_end)

--- a/tests/core/test_api_with_s3.py
+++ b/tests/core/test_api_with_s3.py
@@ -275,53 +275,58 @@ class TestApiWithS3(TestWithS3):
                 assert False, "Fail to parse to JSON"
 
     @patch("aodn_cloud_optimised.lib.DataQuery.REGION", REGION)
-    def test_fetch_data_without_time_ignores_date_range(
+    def test_fetch_data_uses_temporal_extent_column(
         self, setup, localstack, aws_clients, setup_resources, client
     ):
         """
-        aggregated_seagrass_nonqc has no TIME column (only hive timestamp).
-        A requested date range must be ignored so subsetting still returns data.
+        aggregated_seagrass_nonqc dates live in _temporal_extent (date32).
+        A matching date range must return rows; a non-overlapping range empty.
         """
         s3_client, _, _ = aws_clients
         config = Config.get_config()
         config.set_s3_client(s3_client)
 
         with patch.object(AWSHelper, "send_email") as mock_send_email:
-            # Range does not cover the 2025 hive partition; if TIME filtering
-            # were applied this would come back empty.
-            param = {
-                "start_date": "2010-01-01 00:00:00.000000000",
-                "end_date": "2010-12-31 23:59:59.999999999",
-                "columns": ["TIME", "DEPTH", "LATITUDE", "LONGITUDE"],
-            }
-
-            response = client.get(
+            seagrass_url = (
                 config.BASE_URL
-                + "/data/009a1131-efc1-4a61-8f90-cf289e7c043d/aggregated_seagrass_nonqc.parquet",
-                params=param,
-                headers={"X-API-Key": config.get_api_key()},
+                + "/data/009a1131-efc1-4a61-8f90-cf289e7c043d/aggregated_seagrass_nonqc.parquet"
             )
+            headers = {"X-API-Key": config.get_api_key()}
 
-            assert response.status_code == HTTP_200_OK
-            assert isinstance(response.content, bytes)
+            miss = client.get(
+                seagrass_url,
+                params={
+                    "start_date": "2010-01-01 00:00:00.000000000",
+                    "end_date": "2010-12-31 23:59:59.999999999",
+                    "columns": ["TIME", "DEPTH", "LATITUDE", "LONGITUDE"],
+                },
+                headers=headers,
+            )
+            assert miss.status_code == HTTP_200_OK
+            assert json.loads(miss.content.decode("utf-8")) == []
 
-            try:
-                parsed = json.loads(response.content.decode("utf-8"))
-                assert (
-                    len(parsed) == 25
-                ), f"Number of record is incorrect: {len(parsed)}"
-                parsed = sorted(
-                    parsed, key=lambda x: (x["latitude"], x["longitude"], x["time"])
-                )
-                assert parsed[0] == {
-                    "latitude": -40.3,
-                    "longitude": 147.9,
-                    "time": "2025-01-01",
-                }, f"Unexpected JSON content: {parsed[0]}"
-                assert parsed[24] == {
-                    "latitude": -40.1,
-                    "longitude": 148.0,
-                    "time": "2025-01-01",
-                }, f"Unexpected JSON content: {parsed[24]}"
-            except json.JSONDecodeError as e:
-                assert False, "Fail to parse to JSON"
+            hit = client.get(
+                seagrass_url,
+                params={
+                    "start_date": "2025-02-01 00:00:00.000000000",
+                    "end_date": "2025-02-28 23:59:59.999999999",
+                    "columns": ["TIME", "DEPTH", "LATITUDE", "LONGITUDE"],
+                },
+                headers=headers,
+            )
+            assert hit.status_code == HTTP_200_OK
+            parsed = json.loads(hit.content.decode("utf-8"))
+            assert len(parsed) == 25, f"Number of record is incorrect: {len(parsed)}"
+            parsed = sorted(
+                parsed, key=lambda x: (x["latitude"], x["longitude"], x["time"])
+            )
+            assert parsed[0] == {
+                "latitude": -40.3,
+                "longitude": 147.9,
+                "time": "2025-02-23",
+            }, f"Unexpected JSON content: {parsed[0]}"
+            assert parsed[24] == {
+                "latitude": -40.1,
+                "longitude": 148.0,
+                "time": "2025-02-23",
+            }, f"Unexpected JSON content: {parsed[24]}"


### PR DESCRIPTION
1. The seagrass dataset cannot use the normal get_temporal_extents because the time field is not something hardcode in the lib function , we need to pass the field name to it in order get the correct behavior. Otherwise we always fail to locate the right temporal extents