### PR TITLE
fix get_dataset reading full s3

### DIFF
--- a/data_access_service/models/co_data_source/abstract_data_src.py
+++ b/data_access_service/models/co_data_source/abstract_data_src.py
@@ -18,9 +18,17 @@ class AbstractDataSrc(ABC):
     def get_metadata_catalog(self) -> dict:
         pass
 
+    def get_dataset_names(self) -> frozenset[str]:
+        """Names of the datasets held by this source, e.g. {"argo.parquet"}.
+
+        Only used to check whether a name exists, so a source with an expensive
+        catalog should override this with a cheaper listing.
+        """
+        return frozenset(self.get_metadata_catalog())
+
     @abstractmethod
     def get_dataset(self, dataset_name_with_ext: str) -> DataSource:
-        if dataset_name_with_ext not in self.get_metadata_catalog():
+        if dataset_name_with_ext not in self.get_dataset_names():
             raise DatasetNotFoundError(
                 dataset_name=dataset_name_with_ext, data_source_name=self.get_name()
             )

--- a/data_access_service/models/co_data_source/aodn_data_src.py
+++ b/data_access_service/models/co_data_source/aodn_data_src.py
@@ -1,8 +1,5 @@
-from pprint import pprint
-
 from aodn_cloud_optimised.lib.DataQuery import Metadata, DataSource, GetAodn
 
-from data_access_service.exceptions.dataset_not_found_error import DatasetNotFoundError
 from data_access_service.models.co_data_source.abstract_data_src import (
     AbstractDataSrc,
     AODN,
@@ -14,6 +11,7 @@ class AodnDataSrc(AbstractDataSrc):
     def __init__(self):
         self.name = AODN
         self.__data_src = GetAodn()
+        self.__dataset_names: frozenset[str] | None = None
 
     def get_name(self) -> str:
         return self.name
@@ -23,6 +21,11 @@ class AodnDataSrc(AbstractDataSrc):
 
     def get_metadata_catalog(self) -> dict:
         return self.__data_src.get_metadata().catalog
+
+    def get_dataset_names(self) -> frozenset[str]:
+        if self.__dataset_names is None:
+            self.__dataset_names = frozenset(self.__data_src.list_datasets())
+        return self.__dataset_names
 
     def get_dataset(self, dataset_name_with_ext: str) -> DataSource:
         return super().get_dataset(dataset_name_with_ext=dataset_name_with_ext)

--- a/tests/models/co_data_source/test_co_data_source.py
+++ b/tests/models/co_data_source/test_co_data_source.py
@@ -41,6 +41,8 @@ def _make_mock_get_aodn(catalog: dict | None = None) -> MagicMock:
     mock_metadata = MagicMock()
     mock_metadata.catalog = catalog or {KNOWN_DATASET: {}}
     mock_aodn.get_metadata.return_value = mock_metadata
+    # The cheap listing AodnDataSrc uses instead of the metadata catalog.
+    mock_aodn.list_datasets.return_value = list(mock_metadata.catalog)
     return mock_aodn
 
 
@@ -134,6 +136,21 @@ class TestAodnDataSrc:
         src, _ = self._make_src()
         with pytest.raises(DatasetNotFoundError):
             src.get_dataset(UNKNOWN_DATASET)
+
+    def test_get_dataset_does_not_build_the_metadata_catalog(self):
+        # Building the catalog reads every dataset's metadata from S3, so the
+        # name check must not touch it.
+        src, mock_aodn = self._make_src()
+        src.get_dataset(KNOWN_DATASET)
+        mock_aodn.get_metadata.assert_not_called()
+
+    def test_dataset_names_are_listed_once_and_reused(self):
+        src, mock_aodn = self._make_src()
+        src.get_dataset(KNOWN_DATASET)
+        src.get_dataset(KNOWN_DATASET)
+        with pytest.raises(DatasetNotFoundError):
+            src.get_dataset(UNKNOWN_DATASET)
+        mock_aodn.list_datasets.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Issue

Recent PR changes `API._instance` from `DataQuery.GetAodn()` to `CODataRegistry()`, which results:
- `get_dataset()` now checks the name against the full metadata catalog and re-reads every dataset's metadata from S3 on every call (~40s, ~2GB) 
- the library's `@lru_cache` never hits because `GetAodn.get_metadata()` returns a new `Metadata` object each time. 
- this is costly because `get_dataset()` is called on almost every request path (`has_data`, `get_temporal_extent`, `get_datasource`, size estimation), often more than once per request.


## Why not just fix the cache key

The cache lives in `aodn_cloud_optimised`, not in this repo, and its `maxsize=None` would pin the ~2GB catalog for the life of the process. Even if the cache did hit, we would still be loading a full metadata catalog just to answer "does this name exist?".

## Fix

The check only needs dataset names, so `AodnDataSrc` now gets them from `GetAodn.list_datasets()` (one S3 folder listing) instead of the full catalog, and caches the result on the instance. The full catalog is still read once at startup for the uuid map, coordinate ranges and schema field names.