### PR TITLE
Enhance parse_date function to accept timezone and handle

### DIFF
--- a/data_access_service/utils/date_time_utils.py
+++ b/data_access_service/utils/date_time_utils.py
@@ -8,7 +8,7 @@ import pytz
 from pandas import Timestamp
 from functools import wraps
 from typing import Tuple
-from datetime import datetime
+from datetime import datetime, tzinfo
 from inspect import iscoroutinefunction
 
 from dateutil.relativedelta import relativedelta
@@ -29,12 +29,23 @@ MIN_DATE = "1970-01-01T00:00:00Z"
 log = logging.getLogger(__name__)
 
 
+def _to_timezone(
+    ts: pd.Timestamp | NaTType, time_zone: str | tzinfo
+) -> Timestamp | NaTType:
+    """Attach ``time_zone`` to a naive timestamp, or convert an aware one to it."""
+    if ts.tz is None:
+        return ts.tz_localize(time_zone)
+    return ts.tz_convert(time_zone)
+
+
 # parse all common format of date string into given format, such as "%Y-%m-%d"
 def parse_date(
-    date_string: str, format_to_convert: str | None = None, time_zone: str = pytz.UTC
+    date_string: str,
+    format_to_convert: str | None = None,
+    time_zone: str | tzinfo = pytz.UTC,
 ) -> pd.Timestamp | NaTType:
     if format_to_convert is None:
-        return pd.Timestamp(date_string).tz_localize(time_zone)
+        return _to_timezone(pd.Timestamp(date_string), time_zone)
     else:
         # Custom format
         ts = pd.to_datetime(date_string, format=format_to_convert)
@@ -45,7 +56,7 @@ def parse_date(
                 nano_str = frac_part[6:9]
                 nanosec = int(nano_str) if nano_str else 0
                 ts = ts + pd.Timedelta(nanoseconds=nanosec)
-        return ts.tz_localize(time_zone)
+        return _to_timezone(ts, time_zone)
 
 
 def start_of_day_nano(ts: pd.Timestamp) -> pd.Timestamp:

--- a/tests/utils/test_date_time_uils.py
+++ b/tests/utils/test_date_time_uils.py
@@ -79,6 +79,18 @@ class TestDateTimeUtils(unittest.TestCase):
             parse_date(date_string, format_to_convert="%Y-%m-%d"), expected_date
         )
 
+    def test_parse_date_iso_z_suffix(self):
+        expected = pd.Timestamp("2024-04-05T00:00:00", tz=pytz.UTC)
+        self.assertEqual(parse_date("2024-04-05T00:00:00Z"), expected)
+        self.assertEqual(parse_date("2024-04-05T00:00:00z"), expected)
+
+    def test_parse_date_iso_offset_converted_to_utc(self):
+        # 2024-04-05T10:00:00+10:00 is 2024-04-05T00:00:00Z
+        self.assertEqual(
+            parse_date("2024-04-05T10:00:00+10:00"),
+            pd.Timestamp("2024-04-05T00:00:00", tz=pytz.UTC),
+        )
+
     def test_get_final_day_of_(self):
         date = pd.Timestamp(year=2023, month=2, day=15)
         expected_date = pd.Timestamp(


### PR DESCRIPTION
1. Make the function timezone aware so that subsetting will accept time with timezone and convert it back to UTC