### PR TITLE
ensure utc for subsetting and estimation

### DIFF
--- a/data_access_service/batch/subsetting/helpers/parquet_date_ranges.py
+++ b/data_access_service/batch/subsetting/helpers/parquet_date_ranges.py
@@ -29,6 +29,7 @@ from data_access_service.core.constants import (
 from data_access_service.utils.date_time_utils import (
     ensure_timezone,
     split_date_range_binary,
+    to_naive_utc_string,
 )
 
 log = logging.getLogger(__name__)
@@ -109,8 +110,12 @@ def check_rows_with_date_range(
             checked_date_ranges.append({"start_date": start, "end_date": end})
             continue
 
-        start_str = start.strftime("%Y-%m-%d")
-        end_str = end.strftime("%Y-%m-%d")
+        # Full timestamps, not "%Y-%m-%d": create_time_filter compares against
+        # pd.to_datetime(end_str), so a day-only end becomes midnight and the
+        # count covers one instant instead of the range. Counting 0 makes the
+        # loop below drop the range, and that data is never downloaded.
+        start_str = to_naive_utc_string(start)
+        end_str = to_naive_utc_string(end)
 
         try:
             time_filter = create_time_filter(
@@ -240,8 +245,8 @@ def create_customised_time_filter(
             f"Invalid time range after boundary adjustment: {start} >= {end}"
         )
 
-    start_str = start.strftime("%Y-%m-%d")
-    end_str = end.strftime("%Y-%m-%d")
+    start_str = to_naive_utc_string(start)
+    end_str = to_naive_utc_string(end)
 
     partition_start, partition_end = get_timestamps_boundary_values(
         dataset, start_str, end_str

--- a/data_access_service/core/constants.py
+++ b/data_access_service/core/constants.py
@@ -4,6 +4,11 @@ import pandas as pd
 
 from data_access_service.models.bounding_box import BoundingBox
 
+# Marker value for an optional field the user did not provide (dates,
+# multi_polygon, ...). AWS Batch job parameters are plain strings and cannot
+# carry None, so absent values travel as this literal instead.
+NON_SPECIFIED = "non-specified"
+
 # The Unix epoch; earliest timestamp the service works with
 UNIX_EPOCH_UTC: pd.Timestamp = pd.Timestamp("1970-01-01 00:00:00.000000000", tz="UTC")
 

--- a/data_access_service/core/routes/data.py
+++ b/data_access_service/core/routes/data.py
@@ -1,7 +1,6 @@
 import json
 import time
 import uuid as uuid_module
-from datetime import datetime, timezone
 from http import HTTPStatus
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
@@ -26,9 +25,8 @@ from data_access_service.sites.sites import (
 )
 from data_access_service.core.routes.auth import api_key_auth
 from data_access_service.utils.date_time_utils import (
-    DATE_FORMAT,
     MIN_DATE,
-    ensure_timezone,
+    to_utc_iso_z,
 )
 from data_access_service.core.routes.helpers import (
     async_response_json,
@@ -36,6 +34,7 @@ from data_access_service.core.routes.helpers import (
     generate_feature_collection,
     get_site_service,
     require_api_ready,
+    resolve_end_date_param,
     verify_datatime_param,
 )
 from data_access_service.utils.cancellation import Cancellation
@@ -67,13 +66,13 @@ async def has_data(
     request: Request,
     api_instance: API = Depends(require_api_ready),  # noqa: B008
     start_date: str | None = MIN_DATE,
-    end_date: str | None = datetime.now(timezone.utc).strftime(DATE_FORMAT),
+    end_date: str | None = None,
 ):
     logger.info(
         "Request details: %s", json.dumps(dict(request.query_params.multi_items()))
     )
     start_date = verify_datatime_param("start_date", start_date)
-    end_date = verify_datatime_param("end_date", end_date)
+    end_date = resolve_end_date_param(end_date)
     result = str(api_instance.has_data(uuid, key, start_date, end_date)).lower()
     return Response(result, media_type="application/json")
 
@@ -86,8 +85,8 @@ async def get_temporal_extent(
         start_date, end_date = api_instance.get_temporal_extent(uuid, key)
         result = [
             {
-                "start_date": ensure_timezone(start_date).strftime(DATE_FORMAT),
-                "end_date": ensure_timezone(end_date).strftime(DATE_FORMAT),
+                "start_date": to_utc_iso_z(start_date),
+                "end_date": to_utc_iso_z(end_date),
             }
         ]
         return Response(content=json.dumps(result), media_type="application/json")
@@ -224,9 +223,7 @@ async def get_data(
     key: str,
     api_instance: API = Depends(require_api_ready),  # noqa: B008
     start_date: str | None = Query(default=MIN_DATE),
-    end_date: str | None = Query(
-        default=datetime.now(timezone.utc).strftime(DATE_FORMAT)
-    ),
+    end_date: str | None = Query(default=None),
     columns: list[str] | None = Query(default=None),  # noqa: B008
     start_depth: float | None = Query(default=-1.0),
     end_depth: float | None = Query(default=-1.0),
@@ -254,7 +251,7 @@ async def get_data(
         end_depth,
     )
     start_date = verify_datatime_param("start_date", start_date)
-    end_date = verify_datatime_param("end_date", end_date)
+    end_date = resolve_end_date_param(end_date)
 
     sse = f.startswith("sse/")
     compress = "gzip" in request.headers.get("Accept-Encoding", "")

--- a/data_access_service/core/routes/helpers.py
+++ b/data_access_service/core/routes/helpers.py
@@ -183,6 +183,18 @@ def _round_5_decimal(value: float) -> float:
     return round(value, 5)
 
 
+def resolve_end_date_param(req_date: str | None) -> pd.Timestamp:
+    """Validate an optional end_date query param, defaulting to now in UTC.
+
+    "Now" has to be worked out per request. A module-level default is evaluated
+    once at import, so a long-running server keeps answering with the date it
+    started on.
+    """
+    if req_date is None:
+        return pd.Timestamp.now(tz=pytz.UTC)
+    return verify_datatime_param("end_date", req_date)
+
+
 def verify_datatime_param(name: str, req_date: str) -> pd.Timestamp:
     _date = None
 

--- a/data_access_service/core/routes/helpers.py
+++ b/data_access_service/core/routes/helpers.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import os
 import re
-import tempfile
 import threading
 from datetime import datetime, timezone
 from http import HTTPStatus
@@ -20,8 +19,8 @@ import xarray
 import xarray as xr
 from dask.dataframe import DataFrame
 from dateutil import parser
-from fastapi import Depends, HTTPException, Request, BackgroundTasks
-from fastapi.responses import Response, FileResponse
+from fastapi import Depends, HTTPException, Request
+from fastapi.responses import Response
 from geojson import Feature, FeatureCollection
 from pydantic import BaseModel
 
@@ -180,12 +179,6 @@ def _reformat_date(date: str):
     return formatted_date
 
 
-# Not called anywhere, left over from the unfinished feature-collection work.
-def _round_5_decimal(value: float) -> float:
-    # as they are only used for the frontend map display, so we don't need to have too many decimals
-    return round(value, 5)
-
-
 def resolve_end_date_param(req_date: str | None) -> pd.Timestamp:
     """Validate an optional end_date query param, defaulting to now in UTC.
 
@@ -280,14 +273,6 @@ def _verify_depth_param(
         return req_value
 
 
-# Not called anywhere, left over from the unfinished feature-collection work.
-def _verify_to_index_flag_param(flag: str | bool | None) -> bool:
-    if (flag is not None) and bool(flag):
-        return True
-    else:
-        return False
-
-
 # Parallel process records and map the field back to standard name
 def async_response_json(result: AsyncGenerator[dict, None], compress: bool):
     # Thread-safe queue to collect results
@@ -341,49 +326,6 @@ def async_response_json(result: AsyncGenerator[dict, None], compress: bool):
         return response
     else:
         return Response(json.dumps(json_results), media_type="application/json")
-
-
-# Not called by any route, only by tests; get_data uses async_response_json.
-def _response_json(result: Generator[dict, None, None], compress: bool):
-    json_array = json.dumps([x for x in result])
-
-    if compress:
-        response = Response(gzip_compress(json_array), media_type="application/json")
-        response.headers["Content-Encoding"] = "gzip"
-        return response
-    else:
-        return Response(json_array, media_type="application/json")
-
-
-# Not called by any route: get_data only serves f=json.
-# TODO: Need to use the metadata to assign correct type to netcdf, right now field type is wrong
-def _response_netcdf(filtered: pd.DataFrame, background_tasks: BackgroundTasks):
-    # Convert the DataFrame to an xarray Dataset
-    ds = xr.Dataset.from_dataframe(filtered)
-
-    # Create a temporary file
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".nc") as tmp_file:
-        tmp_file_name = tmp_file.name
-        ds.to_netcdf(tmp_file_name)
-
-    # Send the file as a response to the client
-    response = FileResponse(
-        path=tmp_file_name,
-        filename="output.nc",
-        media_type="application/x-netcdf",
-    )
-
-    # Clean up the temporary file after sending the response
-    def _remove_file_if_exists(file_path):
-        """Helper function to remove file if it exists"""
-        try:
-            if os.path.exists(file_path):
-                os.remove(file_path)
-        except Exception as e:
-            logger.error(f"Error removing file {file_path}: {e}")
-
-    background_tasks.add_task(lambda: _remove_file_if_exists(tmp_file_name))
-    return response
 
 
 async def fetch_data(
@@ -523,12 +465,6 @@ def get_site_service(repo: ParquetRepository = Depends(get_repo)):
     from data_access_service.sites.site_feature_service import SiteFeatureService
 
     return SiteFeatureService(repo)
-
-
-# Not called anywhere, and the body was never finished (it returns nothing).
-def calculate_cell_coordinates(lat_min, lat_max, lon_min, lon_max):
-    precision = COORDINATE_INDEX_PRECISION
-    dividing_lats = 10**precision
 
 
 def get_memory_usage_percentage():

--- a/data_access_service/core/routes/helpers.py
+++ b/data_access_service/core/routes/helpers.py
@@ -47,7 +47,9 @@ from data_access_service.sites.sites_repository import (
 )
 from data_access_service.utils.date_time_utils import (
     DATE_FORMAT,
-    ensure_timezone,
+    YEAR_MONTH_DAY,
+    parse_date,
+    to_naive_utc,
 )
 
 logger = init_log(Config.get_config())
@@ -174,10 +176,11 @@ def _generate_partial_json_array(
 # currently only want year, month and date.
 def _reformat_date(date: str):
     parsed_date = parser.isoparse(date)
-    formatted_date = parsed_date.strftime("%Y-%m-%d")
+    formatted_date = parsed_date.strftime(YEAR_MONTH_DAY)
     return formatted_date
 
 
+# Not called anywhere, left over from the unfinished feature-collection work.
 def _round_5_decimal(value: float) -> float:
     # as they are only used for the frontend map display, so we don't need to have too many decimals
     return round(value, 5)
@@ -196,6 +199,11 @@ def resolve_end_date_param(req_date: str | None) -> pd.Timestamp:
 
 
 def verify_datatime_param(name: str, req_date: str) -> pd.Timestamp:
+    """Validate a date query param and return it as a UTC-aware Timestamp.
+
+    Raises HTTP 400 rather than letting a bad string reach the data layer.
+    None passes through, the routes read that as "no bound".
+    """
     _date = None
 
     if req_date is not None and name == "end_date":
@@ -212,9 +220,7 @@ def verify_datatime_param(name: str, req_date: str) -> pd.Timestamp:
 
     try:
         if req_date is not None:
-            _date = pd.Timestamp(req_date)
-            if _date.tz is None:
-                _date = _date.tz_localize(pytz.UTC)
+            _date = parse_date(req_date)
 
     except (ValueError, TypeError):
         error_message = ErrorResponse(
@@ -247,14 +253,14 @@ def parse_utc_datetime(name: str, value: Optional[str]) -> Optional[str]:
     if value is None:
         return None
     try:
-        ts = pd.Timestamp(value)
+        ts = parse_date(value)
     except (ValueError, TypeError):
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST,
             detail=f"Invalid datetime for [{name}]: {value!r}. "
             "Expected ISO 8601, e.g. 2024-01-01T00:00:00Z",
         )
-    return ensure_timezone(ts).tz_convert("UTC").tz_localize(None).isoformat()
+    return to_naive_utc(ts).isoformat()
 
 
 def _verify_depth_param(
@@ -274,6 +280,7 @@ def _verify_depth_param(
         return req_value
 
 
+# Not called anywhere, left over from the unfinished feature-collection work.
 def _verify_to_index_flag_param(flag: str | bool | None) -> bool:
     if (flag is not None) and bool(flag):
         return True
@@ -336,6 +343,7 @@ def async_response_json(result: AsyncGenerator[dict, None], compress: bool):
         return Response(json.dumps(json_results), media_type="application/json")
 
 
+# Not called by any route, only by tests; get_data uses async_response_json.
 def _response_json(result: Generator[dict, None, None], compress: bool):
     json_array = json.dumps([x for x in result])
 
@@ -347,6 +355,7 @@ def _response_json(result: Generator[dict, None, None], compress: bool):
         return Response(json_array, media_type="application/json")
 
 
+# Not called by any route: get_data only serves f=json.
 # TODO: Need to use the metadata to assign correct type to netcdf, right now field type is wrong
 def _response_netcdf(filtered: pd.DataFrame, background_tasks: BackgroundTasks):
     # Convert the DataFrame to an xarray Dataset
@@ -516,6 +525,7 @@ def get_site_service(repo: ParquetRepository = Depends(get_repo)):
     return SiteFeatureService(repo)
 
 
+# Not called anywhere, and the body was never finished (it returns nothing).
 def calculate_cell_coordinates(lat_min, lat_max, lon_min, lon_max):
     precision = COORDINATE_INDEX_PRECISION
     dividing_lats = 10**precision
@@ -529,6 +539,7 @@ def get_memory_usage_percentage():
     return (memory_info.rss / total_memory) * 100
 
 
+# Only reached from the /data/{uuid}/{key}/indexing_values investigation endpoint.
 def round_coordinate_list(coordinate_list: List[float]) -> List[ValueCount]:
     """
     Round a list of coordinates to according to the precision and return a list of ValueCount objects.
@@ -551,6 +562,7 @@ def round_coordinate_list(coordinate_list: List[float]) -> List[ValueCount]:
     return rounded_list
 
 
+# Only reached from the /data/{uuid}/{key}/indexing_values investigation endpoint.
 def round_dates(date_list: List[pandas.Timestamp]):
     """
     Round a list of dates to format YYYY-mm
@@ -576,6 +588,7 @@ def round_dates(date_list: List[pandas.Timestamp]):
     return rounded_dates
 
 
+# Only used by the /data/{uuid}/{key}/indexing_values investigation endpoint.
 def generate_feature_collection(
     dataset: xarray.Dataset,
     lat_key: str,

--- a/data_access_service/models/subset_request.py
+++ b/data_access_service/models/subset_request.py
@@ -3,13 +3,14 @@ from typing import Optional
 
 import pandas as pd
 
+from data_access_service.core.constants import NON_SPECIFIED
 from data_access_service.models.bounding_box import BoundingBox
+from data_access_service.utils.date_time_utils import parse_date
 from data_access_service.utils.format_utils import SUPPORTED_OUTPUT_FORMATS
 
-# Marker value for an optional field the user did not provide (dates,
-# multi_polygon, ...). AWS Batch job parameters are plain strings and cannot
-# carry None, so absent values travel as this literal instead.
-NON_SPECIFIED = "non-specified"
+# Re-exported: NON_SPECIFIED lives in core.constants so date_time_utils can read
+# it without importing this module back (that would be a circular import).
+__all__ = ["NON_SPECIFIED", "SubsetRequest"]
 
 
 @dataclass(frozen=True)
@@ -80,7 +81,10 @@ class SubsetRequest:
         if value == NON_SPECIFIED:
             return None
         try:
-            return pd.Timestamp(value)
+            # parse_date, not pd.Timestamp: it returns UTC-aware either way, so
+            # comparing a bare "2024-01-15" against "2024-01-16T00:00:00Z" below
+            # cannot raise "Cannot compare tz-naive and tz-aware timestamps".
+            return parse_date(value)
         except (ValueError, TypeError) as exc:
             raise ValueError(
                 f"{field_name} must be a parseable date or "

--- a/data_access_service/sites/geojson.py
+++ b/data_access_service/sites/geojson.py
@@ -27,7 +27,6 @@ spec and Mapbox GL.
 from __future__ import annotations
 
 from collections.abc import Iterable
-from datetime import timezone
 from typing import Any
 
 from data_access_service.sites.sites import (
@@ -38,6 +37,7 @@ from data_access_service.sites.sites import (
     SiteFeatureCollection,
     SitePoint,
 )
+from data_access_service.utils.date_time_utils import to_utc_iso_z
 
 
 def _native(value: Any) -> Any:
@@ -46,13 +46,24 @@ def _native(value: Any) -> Any:
 
 
 def _iso(value: Any) -> str:
-    """Render a timestamp as an ISO 8601 string with an explicit UTC marker."""
-    iso = getattr(value, "isoformat", None)
-    if not callable(iso):
+    """Render a timestamp as an ISO 8601 string with an explicit UTC marker.
+
+    A string is passed through untouched. Anything else that is not a timestamp falls back to str().
+
+    :param value: a timestamp (a naive one is read as UTC), or any other value
+    :return: string like "2024-01-15T00:00:00Z"; a non-timestamp is returned
+        as its own string form
+
+    Example:
+        _iso(pd.Timestamp("2024-01-15T10:00:00+10:00")) -> "2024-01-15T00:00:00Z"
+        _iso("2024-01-01") -> "2024-01-01"
+    """
+    if isinstance(value, str):
+        return value
+    try:
+        return to_utc_iso_z(value)
+    except (TypeError, ValueError):
         return str(value)
-    if getattr(value, "tzinfo", None) is not None:
-        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
-    return f"{iso()}Z"
 
 
 def _point(longitude: Any, latitude: Any) -> SitePoint:

--- a/data_access_service/tiler/utils/dates.py
+++ b/data_access_service/tiler/utils/dates.py
@@ -1,12 +1,13 @@
-"""Pure date utility functions shared across routers and services.
-"""
+"""Pure date utility functions shared across routers and services."""
 
 import pandas as pd
+
+from data_access_service.utils.date_time_utils import to_utc_iso_z
 
 
 def ts_to_utc_iso(ts) -> str:
     """Format a raw (naive UTC) store timestamp as a canonical UTC ISO-8601 string."""
-    return pd.Timestamp(ts).tz_localize("UTC").isoformat().replace("+00:00", "Z")
+    return to_utc_iso_z(ts)
 
 
 def str_to_utc_timestamp(date: str, *, require_tz: bool = False) -> pd.Timestamp:

--- a/data_access_service/utils/date_time_utils.py
+++ b/data_access_service/utils/date_time_utils.py
@@ -82,14 +82,14 @@ def parse_date(
     return _to_timezone(ts, time_zone)
 
 
-def end_of_day_nano(ts: pd.Timestamp) -> pd.Timestamp:
+def _end_of_day_nano(ts: pd.Timestamp) -> pd.Timestamp:
     """Move a timestamp to the last nanosecond of its day.
 
     :param ts: any timestamp
     :return: the same day at 23:59:59.999999999
 
     Example:
-        end_of_day_nano("2024-01-15 10:00") -> "2024-01-15 23:59:59.999999999"
+        _end_of_day_nano("2024-01-15 10:00") -> "2024-01-15 23:59:59.999999999"
     """
     # a coarser-resolution timestamp (e.g. "us") silently drops the
     # nanosecond=999 in replace(), so force nanosecond resolution first
@@ -101,39 +101,6 @@ def end_of_day_nano(ts: pd.Timestamp) -> pd.Timestamp:
         # pyrefly: ignore [unexpected-keyword]
         nanosecond=999,
     )
-
-
-def get_final_day_of_month_(date: pd.Timestamp) -> pd.Timestamp:
-    """Move a timestamp to the last nanosecond of its month.
-
-    :param date: any timestamp; a naive one is read as UTC
-    :return: last day of that month at 23:59:59.999999999, UTC-aware
-
-    Example:
-        get_final_day_of_month_("2024-02-05") -> "2024-02-29 23:59:59.999999999+00:00"
-    """
-    if date.tz is None:
-        date = date.tz_localize(pytz.UTC)
-    return end_of_day_nano(date + pd.offsets.MonthEnd(0))
-
-
-def get_first_day_of_month(date: pd.Timestamp) -> pd.Timestamp:
-    """Roll a timestamp forward to a month's first day at midnight.
-
-    Despite the name, only a date already on the 1st stays in its own month;
-    any later day rolls forward to the NEXT month, because pandas' MonthBegin(0)
-    rolls forward. The one caller always passes the 1st, so this is safe today -
-    but do not reuse it on an arbitrary date without checking.
-
-    :param date: any timestamp; its timezone is kept as-is
-    :return: a month's first day at 00:00:00
-
-    Example:
-        get_first_day_of_month("2024-02-01 18:30") -> "2024-02-01 00:00:00"
-        get_first_day_of_month("2024-02-15 18:30") -> "2024-03-01 00:00:00"  (!)
-    """
-    first_day = date + pd.offsets.MonthBegin(0)
-    return first_day.normalize()
 
 
 def ensure_timezone(dt: pd.Timestamp | NaTType) -> pd.Timestamp | NaTType:
@@ -163,15 +130,18 @@ def to_utc_iso_z(ts: pd.Timestamp) -> str:
 
     strftime("%z") would write "+0000" with no colon, which is not one of the
     two forms the ECMAScript date-time format defines, so JS would parse it on
-    browser goodwill rather than by spec.
+    browser goodwill rather than by spec. isoformat() keeps whatever precision
+    the value carries, so an end bound is never silently truncated - the tiler
+    also relies on that to look a slice up by its exact instant.
 
     :param ts: any timestamp; a naive one is read as UTC
-    :return: string like "2024-01-15T00:00:00Z" (seconds precision)
+    :return: string like "2024-01-15T00:00:00Z", sub-second digits kept
 
     Example:
         to_utc_iso_z("2024-01-15T10:00:00+10:00") -> "2024-01-15T00:00:00Z"
+        to_utc_iso_z("2024-01-15 00:00:00.123456") -> "2024-01-15T00:00:00.123456Z"
     """
-    return ensure_timezone(pd.Timestamp(ts)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return ensure_timezone(pd.Timestamp(ts)).isoformat().replace("+00:00", "Z")
 
 
 def to_naive_utc(ts: pd.Timestamp | None) -> pd.Timestamp | None:
@@ -377,7 +347,7 @@ def resolve_non_specified_dates(start_date: str, end_date: str) -> Tuple[str, st
     """Replace the "non-specified" markers with the default open bounds.
 
     The end default carries full nanosecond precision. A day-only end would
-    become the end of that day only if end_of_specified_precision happened to
+    become the end of that day only if _end_of_specified_precision happened to
     run downstream; spelling it out here means the value is already the instant
     it claims to be.
 
@@ -398,82 +368,8 @@ def resolve_non_specified_dates(start_date: str, end_date: str) -> Tuple[str, st
     if end_date == NON_SPECIFIED:
         # now(tz="UTC") rather than today(), which reads the host clock and so
         # returns the wrong calendar day on any machine not pinned to UTC.
-        end_date = end_of_day_nano(pd.Timestamp.now(tz="UTC")).isoformat()
+        end_date = _end_of_day_nano(pd.Timestamp.now(tz="UTC")).isoformat()
     return start_date, end_date
-
-
-def has_explicit_time(date_string: str) -> bool:
-    """Tell whether a date string carries a clock time, not just a calendar date.
-
-    :param date_string: the raw string to inspect
-    :return: True when an "HH:MM" part is present
-
-    Example:
-        has_explicit_time("2024-01-15") -> False
-        has_explicit_time("2024-01-15T10:00:00Z") -> True
-    """
-    return bool(re.search(r"[T ]\d{2}:\d{2}", date_string))
-
-
-def end_of_specified_precision(date_string: str, ts: pd.Timestamp) -> pd.Timestamp:
-    """Widen an inclusive end bound to the last nanosecond of the precision given.
-
-    A bare date means that whole day, a whole second means that second. Only
-    those two precisions are recognised: a minute-only bound like
-    "2024-01-15T10:00" is read as second 00 and widens to 10:00:00.999999999,
-    not to the end of the minute. The portal always sends seconds.
-
-    The portal builds its end as 23:59:59.999 but formats it with
-    "YYYY-MM-DDTHH:mm:ss[Z]", dropping the milliseconds; taking that at face
-    value would leave the last second of every day outside both this range and
-    the next, so nothing could ever download it.
-
-    :param date_string: the raw string the bound was given as
-    :param ts: that same string, already parsed
-    :return: `ts` moved to the end of the unit `date_string` specified
-
-    Example:
-        end_of_specified_precision("2024-01-15", ts)
-        -> "2024-01-15 23:59:59.999999999+00:00"   (a date means the whole day)
-        end_of_specified_precision("2024-01-15T10:00:00Z", ts)
-        -> "2024-01-15 10:00:00.999999999+00:00"   (a second means that second)
-    """
-    if not has_explicit_time(date_string):
-        return end_of_day_nano(ts)
-
-    fraction = re.search(r"[T ]\d{2}:\d{2}:\d{2}\.(\d+)", date_string)
-    digits = len(fraction.group(1)) if fraction else 0
-    if digits >= 9:
-        return ts
-    # fill the digits the caller left unspecified with 9s
-    return ts + pd.Timedelta(nanoseconds=10 ** (9 - digits) - 1)
-
-
-# The legacy bound format the portal used to send, e.g. "02-2024".
-MONTH_ONLY_PATTERN = re.compile(r"^(0[1-9]|1[0-2])-\d{4}$")
-
-
-def _month_to_iso(date_string: str, *, is_end: bool) -> str:
-    """Rewrite a legacy "MM-YYYY" bound as the ISO date it means.
-
-    The portal sends ISO now. Converting here keeps the one place that still
-    understands the old format at the entry, so nothing downstream has to.
-
-    :param date_string: raw bound; anything not "MM-YYYY" is returned untouched
-    :param is_end: True picks the last day of the month, False the first
-    :return: a "YYYY-MM-DD" string
-
-    Example:
-        _month_to_iso("02-2024", is_end=False) -> "2024-02-01"
-        _month_to_iso("02-2024", is_end=True) -> "2024-02-29"
-        _month_to_iso("2024-02-15", is_end=True) -> "2024-02-15"  (not MM-YYYY)
-    """
-    if not MONTH_ONLY_PATTERN.match(date_string):
-        return date_string
-
-    month = parse_date(date_string, format_to_convert="%m-%Y")
-    day = get_final_day_of_month_(month) if is_end else get_first_day_of_month(month)
-    return day.strftime(YEAR_MONTH_DAY)
 
 
 def to_utc_bounds(
@@ -499,8 +395,115 @@ def to_utc_bounds(
 
     return (
         parse_date(start_date_str),
-        end_of_specified_precision(end_date_str, parse_date(end_date_str)),
+        _end_of_specified_precision(end_date_str, parse_date(end_date_str)),
     )
+
+
+# The legacy bound format the portal used to send, e.g. "02-2024".
+_MONTH_ONLY_PATTERN = re.compile(r"^(0[1-9]|1[0-2])-\d{4}$")
+
+
+def _month_to_iso(date_string: str, *, is_end: bool) -> str:
+    """Rewrite a legacy "MM-YYYY" bound as the ISO date it means.
+
+    The portal sends ISO now. Converting here keeps the one place that still
+    understands the old format at the entry, so nothing downstream has to.
+
+    :param date_string: raw bound; anything not "MM-YYYY" is returned untouched
+    :param is_end: True picks the last day of the month, False the first
+    :return: a "YYYY-MM-DD" string
+
+    Example:
+        _month_to_iso("02-2024", is_end=False) -> "2024-02-01"
+        _month_to_iso("02-2024", is_end=True) -> "2024-02-29"
+        _month_to_iso("2024-02-15", is_end=True) -> "2024-02-15"  (not MM-YYYY)
+    """
+    if not _MONTH_ONLY_PATTERN.match(date_string):
+        return date_string
+
+    month = parse_date(date_string, format_to_convert="%m-%Y")
+    day = _get_final_day_of_month(month) if is_end else _get_first_day_of_month(month)
+    return day.strftime(YEAR_MONTH_DAY)
+
+
+def _get_final_day_of_month(date: pd.Timestamp) -> pd.Timestamp:
+    """Move a timestamp to the last nanosecond of its month.
+
+    :param date: any timestamp; a naive one is read as UTC
+    :return: last day of that month at 23:59:59.999999999, UTC-aware
+
+    Example:
+        _get_final_day_of_month("2024-02-05") -> "2024-02-29 23:59:59.999999999+00:00"
+    """
+    if date.tz is None:
+        date = date.tz_localize(pytz.UTC)
+    return _end_of_day_nano(date + pd.offsets.MonthEnd(0))
+
+
+def _get_first_day_of_month(date: pd.Timestamp) -> pd.Timestamp:
+    """Roll a timestamp forward to a month's first day at midnight.
+
+    Despite the name, only a date already on the 1st stays in its own month;
+    any later day rolls forward to the NEXT month, because pandas' MonthBegin(0)
+    rolls forward. The one caller always passes the 1st, so this is safe today -
+    but do not reuse it on an arbitrary date without checking.
+
+    :param date: any timestamp; its timezone is kept as-is
+    :return: a month's first day at 00:00:00
+
+    Example:
+        _get_first_day_of_month("2024-02-01 18:30") -> "2024-02-01 00:00:00"
+        _get_first_day_of_month("2024-02-15 18:30") -> "2024-03-01 00:00:00"  (!)
+    """
+    first_day = date + pd.offsets.MonthBegin(0)
+    return first_day.normalize()
+
+
+def _end_of_specified_precision(date_string: str, ts: pd.Timestamp) -> pd.Timestamp:
+    """Widen an inclusive end bound to the last nanosecond of the precision given.
+
+    A bare date means that whole day, a whole second means that second. Only
+    those two precisions are recognised: a minute-only bound like
+    "2024-01-15T10:00" is read as second 00 and widens to 10:00:00.999999999,
+    not to the end of the minute. The portal always sends seconds.
+
+    The portal builds its end as 23:59:59.999 but formats it with
+    "YYYY-MM-DDTHH:mm:ss[Z]", dropping the milliseconds; taking that at face
+    value would leave the last second of every day outside both this range and
+    the next, so nothing could ever download it.
+
+    :param date_string: the raw string the bound was given as
+    :param ts: that same string, already parsed
+    :return: `ts` moved to the end of the unit `date_string` specified
+
+    Example:
+        _end_of_specified_precision("2024-01-15", ts)
+        -> "2024-01-15 23:59:59.999999999+00:00"   (a date means the whole day)
+        _end_of_specified_precision("2024-01-15T10:00:00Z", ts)
+        -> "2024-01-15 10:00:00.999999999+00:00"   (a second means that second)
+    """
+    if not _has_explicit_time(date_string):
+        return _end_of_day_nano(ts)
+
+    fraction = re.search(r"[T ]\d{2}:\d{2}:\d{2}\.(\d+)", date_string)
+    digits = len(fraction.group(1)) if fraction else 0
+    if digits >= 9:
+        return ts
+    # fill the digits the caller left unspecified with 9s
+    return ts + pd.Timedelta(nanoseconds=10 ** (9 - digits) - 1)
+
+
+def _has_explicit_time(date_string: str) -> bool:
+    """Tell whether a date string carries a clock time, not just a calendar date.
+
+    :param date_string: the raw string to inspect
+    :return: True when an "HH:MM" part is present
+
+    Example:
+        _has_explicit_time("2024-01-15") -> False
+        _has_explicit_time("2024-01-15T10:00:00Z") -> True
+    """
+    return bool(re.search(r"[T ]\d{2}:\d{2}", date_string))
 
 
 def split_date_range(

--- a/data_access_service/utils/date_time_utils.py
+++ b/data_access_service/utils/date_time_utils.py
@@ -1,3 +1,9 @@
+"""Date and time helpers. Everything here works in UTC.
+
+In the examples a quoted value stands for the pd.Timestamp of that instant,
+e.g. "2024-01-15 10:00" means pd.Timestamp("2024-01-15 10:00").
+"""
+
 import logging
 import re
 import time
@@ -8,16 +14,14 @@ import pytz
 from pandas import Timestamp
 from functools import wraps
 from typing import Tuple
-from datetime import datetime, tzinfo
+from datetime import tzinfo
 from inspect import iscoroutinefunction
 
-from dateutil.relativedelta import relativedelta
 from pandas._libs import NaTType
 
-from data_access_service.models.subset_request import NON_SPECIFIED
+from data_access_service.core.constants import NON_SPECIFIED
 
 YEAR_MONTH_DAY = "%Y-%m-%d"
-YEAR_MONTH_DAY_TIME_NANO = "%Y-%m-%d %H:%M:%S.fffffffff"
 
 # %z do not produce Z for +0000, %z just add the offset value which is fine
 # for client, however if you prefer to have Z the please replace the string
@@ -32,47 +36,61 @@ log = logging.getLogger(__name__)
 def _to_timezone(
     ts: pd.Timestamp | NaTType, time_zone: str | tzinfo
 ) -> Timestamp | NaTType:
-    """Attach ``time_zone`` to a naive timestamp, or convert an aware one to it."""
+    """Attach a timezone to a naive timestamp, or convert an aware one to it.
+
+    :param ts: naive or timezone-aware timestamp, or NaT
+    :param time_zone: target timezone, e.g. pytz.UTC or "Asia/Tokyo"
+    :return: the same instant expressed in `time_zone`; NaT passes through
+
+    Example:
+        _to_timezone("2024-01-15 10:00", pytz.UTC) -> "2024-01-15 10:00:00+00:00"
+    """
     if ts.tz is None:
         return ts.tz_localize(time_zone)
     return ts.tz_convert(time_zone)
 
 
-# parse all common format of date string into given format, such as "%Y-%m-%d"
 def parse_date(
     date_string: str,
     format_to_convert: str | None = None,
     time_zone: str | tzinfo = pytz.UTC,
 ) -> pd.Timestamp | NaTType:
+    """Parse a date string into a timezone-aware timestamp.
+
+    A string with no offset is read as `time_zone`; one that already carries
+    `Z` or an offset is converted, never re-localized - tz_localize() raises on
+    an aware value, which is what used to crash subsetting on the ISO-8601 a JS
+    date picker produces.
+
+    :param date_string: date to parse, e.g. "2024-01-15" or "2024-01-15T10:00:00Z"
+    :param format_to_convert: strptime format, for a string that is not ISO-8601
+    :param time_zone: timezone to read a string with no offset as (UTC by default)
+    :return: timestamp in `time_zone`, or NaT when the value parses to NaT
+
+    Example:
+        parse_date("2024-01-15") -> "2024-01-15 00:00:00+00:00"
+        parse_date("2024-01-15T10:00:00+10:00") -> "2024-01-15 00:00:00+00:00"
+    """
     if format_to_convert is None:
-        return _to_timezone(pd.Timestamp(date_string), time_zone)
+        ts = pd.Timestamp(date_string)
     else:
-        # Custom format
+        # pd.to_datetime keeps all 9 digits of a "%f" fraction. There used to be
+        # a manual fix-up adding the last 3 digits back, written for
+        # datetime.strptime, which stops at microseconds - on pandas it added
+        # them a second time (.123456789 became .123457578).
         ts = pd.to_datetime(date_string, format=format_to_convert)
-        # Extract nanoseconds if present
-        if "%f" in format_to_convert:
-            frac_part = date_string.split(".")[-1].split("+")[0]
-            if len(frac_part) > 6:
-                nano_str = frac_part[6:9]
-                nanosec = int(nano_str) if nano_str else 0
-                ts = ts + pd.Timedelta(nanoseconds=nanosec)
-        return _to_timezone(ts, time_zone)
-
-
-def start_of_day_nano(ts: pd.Timestamp) -> pd.Timestamp:
-    """Floor a timestamp to the first nanosecond of its day (00:00:00.000000000)."""
-    return ts.replace(
-        hour=0,
-        minute=0,
-        second=0,
-        microsecond=0,
-        # pyrefly: ignore [unexpected-keyword]
-        nanosecond=0,
-    )
+    return _to_timezone(ts, time_zone)
 
 
 def end_of_day_nano(ts: pd.Timestamp) -> pd.Timestamp:
-    """Ceil a timestamp to the final nanosecond of its day (23:59:59.999999999)."""
+    """Move a timestamp to the last nanosecond of its day.
+
+    :param ts: any timestamp
+    :return: the same day at 23:59:59.999999999
+
+    Example:
+        end_of_day_nano("2024-01-15 10:00") -> "2024-01-15 23:59:59.999999999"
+    """
     # a coarser-resolution timestamp (e.g. "us") silently drops the
     # nanosecond=999 in replace(), so force nanosecond resolution first
     return ts.as_unit("ns").replace(
@@ -86,45 +104,88 @@ def end_of_day_nano(ts: pd.Timestamp) -> pd.Timestamp:
 
 
 def get_final_day_of_month_(date: pd.Timestamp) -> pd.Timestamp:
+    """Move a timestamp to the last nanosecond of its month.
+
+    :param date: any timestamp; a naive one is read as UTC
+    :return: last day of that month at 23:59:59.999999999, UTC-aware
+
+    Example:
+        get_final_day_of_month_("2024-02-05") -> "2024-02-29 23:59:59.999999999+00:00"
+    """
     if date.tz is None:
         date = date.tz_localize(pytz.UTC)
     return end_of_day_nano(date + pd.offsets.MonthEnd(0))
 
 
 def get_first_day_of_month(date: pd.Timestamp) -> pd.Timestamp:
-    """
-    Find first day of month, do not care about the timezone and time
-    :param date:
-    :return:
+    """Roll a timestamp forward to a month's first day at midnight.
+
+    Despite the name, only a date already on the 1st stays in its own month;
+    any later day rolls forward to the NEXT month, because pandas' MonthBegin(0)
+    rolls forward. The one caller always passes the 1st, so this is safe today -
+    but do not reuse it on an arbitrary date without checking.
+
+    :param date: any timestamp; its timezone is kept as-is
+    :return: a month's first day at 00:00:00
+
+    Example:
+        get_first_day_of_month("2024-02-01 18:30") -> "2024-02-01 00:00:00"
+        get_first_day_of_month("2024-02-15 18:30") -> "2024-03-01 00:00:00"  (!)
     """
     first_day = date + pd.offsets.MonthBegin(0)
     return first_day.normalize()
 
 
-def next_month_first_day(date: pd.Timestamp) -> pd.Timestamp:
-    first_day = get_final_day_of_month_(date) + pd.offsets.Day(1)
-    return pd.Timestamp(
-        year=first_day.year, month=first_day.month, day=first_day.day, tz=first_day.tz
-    )
-
-
 def ensure_timezone(dt: pd.Timestamp | NaTType) -> pd.Timestamp | NaTType:
-    """
-    Check if datetime has timezone info; if not, assume UTC.
+    """Normalise a timestamp to UTC.
 
-    Args:
-        dt: Input datetime object
+    A naive value is assumed to be UTC; an aware value is converted, so the
+    instant never moves but the offset is always +00:00. Keeping the client's
+    own offset would compare correctly yet be wrong to strftime() or strip the
+    tz from, which several callers do.
 
-    Returns:
-        Datetime object with timezone info (UTC if none was present)
+    :param dt: naive or aware timestamp, or NaT
+    :return: the same instant in UTC; NaT passes through
+
+    Example:
+        ensure_timezone("2024-01-15 10:00") -> "2024-01-15 10:00:00+00:00"
+        ensure_timezone("2024-01-15T10:00:00+10:00") -> "2024-01-15 00:00:00+00:00"
     """
-    if dt.tz is None and not isinstance(dt, NaTType):
+    if isinstance(dt, NaTType):
+        return dt
+    if dt.tz is None:
         return dt.tz_localize(pytz.UTC)
-    return dt
+    return dt.tz_convert(pytz.UTC)
+
+
+def to_utc_iso_z(ts: pd.Timestamp) -> str:
+    """Format a timestamp for the API as ISO-8601 UTC with a `Z` suffix.
+
+    strftime("%z") would write "+0000" with no colon, which is not one of the
+    two forms the ECMAScript date-time format defines, so JS would parse it on
+    browser goodwill rather than by spec.
+
+    :param ts: any timestamp; a naive one is read as UTC
+    :return: string like "2024-01-15T00:00:00Z" (seconds precision)
+
+    Example:
+        to_utc_iso_z("2024-01-15T10:00:00+10:00") -> "2024-01-15T00:00:00Z"
+    """
+    return ensure_timezone(pd.Timestamp(ts)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def to_naive_utc(ts: pd.Timestamp | None) -> pd.Timestamp | None:
-    """Convert a timestamp to naive UTC for slicing the zarr time coordinate, which cannot be compared against timezone-aware values.None passes through so an open slice stays open."""
+    """Drop the timezone from a timestamp, keeping the UTC instant.
+
+    The zarr time coordinate is tz-naive and cannot be compared against a
+    timezone-aware value.
+
+    :param ts: any timestamp, or None
+    :return: naive UTC timestamp; None passes through so an open slice stays open
+
+    Example:
+        to_naive_utc("2024-01-15T10:00:00+10:00") -> "2024-01-15 00:00:00"
+    """
     if ts is None:
         return None
     if ts.tz is not None:
@@ -132,26 +193,45 @@ def to_naive_utc(ts: pd.Timestamp | None) -> pd.Timestamp | None:
     return ts
 
 
+def to_naive_utc_string(ts: pd.Timestamp) -> str:
+    """Format a timestamp as a naive-UTC string, all 9 fraction digits kept.
+
+    The parquet time columns are tz-naive TIMESTAMP_NS holding UTC, and the
+    filter builders compare them against pd.to_datetime(<this string>), so the
+    value has to be naive UTC. "%Y-%m-%d" instead would collapse the end of a
+    range to midnight and lose the rest of the day.
+
+    :param ts: any timestamp; a naive one is read as UTC
+    :return: string like "2024-01-15 23:59:59.999999999"
+
+    Example:
+        to_naive_utc_string("2024-01-15 23:59:59.999999999+00:00")
+        -> "2024-01-15 23:59:59.999999999"
+    """
+    ts = to_naive_utc(ensure_timezone(pd.Timestamp(ts)))
+    return f"{ts.strftime('%Y-%m-%d %H:%M:%S.%f')}{ts.nanosecond:03d}"
+
+
 def split_date_range_binary(
     start_date: Timestamp, end_date: Timestamp
 ) -> tuple[Timestamp, Timestamp | NaTType, Timestamp | NaTType, Timestamp]:
-    """
-    Binary-split a date range into two adjacent, non-overlapping inclusive halves.
+    """Split a date range into two halves that touch but never overlap.
 
-    Filters treat both ends as inclusive, so the split uses a 1ns gap at the mid
-    point: left is [start, mid_exclusive_end] and right is [right_start, end],
-    with mid_exclusive_end + 1ns == right_start. Together they cover [start, end]
-    without sharing any timestamp.
+    Filters treat both ends as inclusive, so the halves are separated by a 1ns
+    gap: left_end + 1ns == right_start. Together they still cover the whole
+    range, without sharing any timestamp.
 
-    Args:
-        start_date: Inclusive start of the range (UTC).
-        end_date: Inclusive end of the range (UTC).
+    :param start_date: inclusive start; a naive value is read as UTC and a
+        string is coerced to a Timestamp
+    :param end_date: inclusive end, same handling
+    :return: (left_start, left_end, right_start, right_end), all UTC-aware
+    :raises ValueError: if either bound is NaT, if end is before start, or if
+        start == end - a zero-length range has no two halves. A range of one
+        nanosecond is fine: it holds two ticks, one for each half.
 
-    Returns:
-        (left_start, left_end, right_start, right_end)
-
-    Raises:
-        ValueError: If the range is too short to split into two non-empty halves.
+    Example:
+        split_date_range_binary("2024-01-01", "2024-01-03") -> left half ends
+        "2024-01-01 23:59:59.999999999", right half starts "2024-01-02 00:00:00"
     """
     if not isinstance(start_date, pd.Timestamp):
         start_date = pd.Timestamp(start_date)
@@ -201,16 +281,24 @@ def split_date_range_binary(
 def get_monthly_utc_date_range_array_from_(
     start_date: pd.Timestamp, end_date: pd.Timestamp
 ) -> list[dict]:
-    """
-    Split a date range into monthly intervals, preserving start_date and using exact end_date for the last month.
+    """Split a date range into one entry per calendar month.
 
-    Args:
-        start_date (pd.Timestamp): Start date with nanosecond precision.
-        end_date (pd.Timestamp): End date with nanosecond precision.
+    The first entry keeps the exact start_date and the last keeps the exact
+    end_date; every month in between runs midnight to end-of-day.
 
-    Returns:
-        list[dict]: List of dictionaries with 'start_date' and 'end_date' as UTC strings in
-                    'YYYY-MM-DD HH:MM:SS.fffffffff+00:00' format.
+    One exception: when start_date is the last day of its month, that day is
+    merged into the next month's entry instead of getting one of its own. The
+    range is still covered in full, the caller just gets a wider window.
+
+    :param start_date: start of the range; a naive one is read as UTC
+    :param end_date: end of the range; a naive one is read as UTC
+    :return: list of {"start_date": Timestamp, "end_date": Timestamp}, UTC-aware
+    :raises ValueError: if start_date is after end_date
+
+    Example:
+        get_monthly_utc_date_range_array_from_("2024-01-15", "2024-03-10")
+        -> 3 entries starting 2024-01-15, 2024-02-01 and 2024-03-01, the last
+           one ending at the requested 2024-03-10
     """
     # Check if start_date > end_date
     if start_date > end_date:
@@ -285,107 +373,134 @@ def get_monthly_utc_date_range_array_from_(
     return result
 
 
-def get_boundary_of_year_month(
-    year_month_str: str,
-) -> Tuple[datetime, datetime]:
-    """
-    Get the first and last day of the month for a given year and month.
-
-    Args:
-        year_month_str (str): Year and month in the format "YYYY-MM".
-
-    Returns:
-        Tuple[datetime, datetime]: First and last day of the month.
-    """
-    try:
-        year_month = parse_date(year_month_str, "%Y-%m")
-    except Exception as ex:
-        year_month = parse_date(year_month_str, "%m-%Y")
-
-    start_date = year_month.replace(day=1, hour=0, minute=0, second=0)
-    end_date = get_final_day_of_month_(start_date)
-
-    return start_date, end_date
-
-
-def transfer_date_range_into_yearmonth(start_date: str, end_date: str) -> list[dict]:
-    """
-    Transfer a date range into a list of dictionaries with year and month. currently, according to the
-    request from the frontend, the start & end date is in the format of "MM-yyyy"
-
-    Args:
-        start_date (str): Start date in the format "MM-yyyy".
-        end_date (str): End date in the format "MM-yyyy".
-
-    Returns:
-        list[dict]: List of dictionaries with year month in "MM-yyyy" format.
-    """
-    start = datetime.strptime(start_date, "%m-%Y")
-    end = datetime.strptime(end_date, "%m-%Y")
-    result = []
-
-    while start <= end:
-        result.append(start.strftime("%m-%Y"))
-        start += relativedelta(months=1)
-
-    return result
-
-
-def split_yearmonths_into_dict(yearmonths, chunk_size: int):
-    """
-    Split a list of yearmonths into a dictionary with chunks of a given size.
-
-    Args:
-        yearmonths (list): List of yearmonth strings.
-        chunk_size (int): Size of each chunk (default is 4).
-
-    Returns:
-        dict: Dictionary where keys are indices and values are chunks of yearmonths.
-    """
-    result = {}
-    for i in range(0, len(yearmonths), chunk_size):
-        result[i // chunk_size] = yearmonths[i : i + chunk_size]
-    return result
-
-
 def resolve_non_specified_dates(start_date: str, end_date: str) -> Tuple[str, str]:
-    """
-    Resolve non-specified start and end dates to default values.
-    defaults: 1970-01-01 for an open start and today for an open end.
+    """Replace the "non-specified" markers with the default open bounds.
+
+    The end default carries full nanosecond precision. A day-only end would
+    become the end of that day only if end_of_specified_precision happened to
+    run downstream; spelling it out here means the value is already the instant
+    it claims to be.
+
+    :param start_date: raw start bound, or NON_SPECIFIED
+    :param end_date: raw end bound, or NON_SPECIFIED
+    :return: (start, end) strings - the epoch and the end of today (UTC) for an
+        open bound. Any other value is returned untouched and still a string;
+        to_utc_bounds is what parses it later.
+
+    Example:
+        resolve_non_specified_dates("non-specified", "non-specified")
+        -> ("1970-01-01T00:00:00Z", "<today>T23:59:59.999999999+00:00")
+        resolve_non_specified_dates("2024-01-15", "2024-01-16")
+        -> ("2024-01-15", "2024-01-16")   (no marker, so nothing to replace)
     """
     if start_date == NON_SPECIFIED:
-        start_date = "1970-01-01"
+        start_date = MIN_DATE
     if end_date == NON_SPECIFIED:
-        end_date = pd.Timestamp.today().strftime("%Y-%m-%d")
+        # now(tz="UTC") rather than today(), which reads the host clock and so
+        # returns the wrong calendar day on any machine not pinned to UTC.
+        end_date = end_of_day_nano(pd.Timestamp.now(tz="UTC")).isoformat()
     return start_date, end_date
 
 
-def supply_day_with_nano_precision(
+def has_explicit_time(date_string: str) -> bool:
+    """Tell whether a date string carries a clock time, not just a calendar date.
+
+    :param date_string: the raw string to inspect
+    :return: True when an "HH:MM" part is present
+
+    Example:
+        has_explicit_time("2024-01-15") -> False
+        has_explicit_time("2024-01-15T10:00:00Z") -> True
+    """
+    return bool(re.search(r"[T ]\d{2}:\d{2}", date_string))
+
+
+def end_of_specified_precision(date_string: str, ts: pd.Timestamp) -> pd.Timestamp:
+    """Widen an inclusive end bound to the last nanosecond of the precision given.
+
+    A bare date means that whole day, a whole second means that second. Only
+    those two precisions are recognised: a minute-only bound like
+    "2024-01-15T10:00" is read as second 00 and widens to 10:00:00.999999999,
+    not to the end of the minute. The portal always sends seconds.
+
+    The portal builds its end as 23:59:59.999 but formats it with
+    "YYYY-MM-DDTHH:mm:ss[Z]", dropping the milliseconds; taking that at face
+    value would leave the last second of every day outside both this range and
+    the next, so nothing could ever download it.
+
+    :param date_string: the raw string the bound was given as
+    :param ts: that same string, already parsed
+    :return: `ts` moved to the end of the unit `date_string` specified
+
+    Example:
+        end_of_specified_precision("2024-01-15", ts)
+        -> "2024-01-15 23:59:59.999999999+00:00"   (a date means the whole day)
+        end_of_specified_precision("2024-01-15T10:00:00Z", ts)
+        -> "2024-01-15 10:00:00.999999999+00:00"   (a second means that second)
+    """
+    if not has_explicit_time(date_string):
+        return end_of_day_nano(ts)
+
+    fraction = re.search(r"[T ]\d{2}:\d{2}:\d{2}\.(\d+)", date_string)
+    digits = len(fraction.group(1)) if fraction else 0
+    if digits >= 9:
+        return ts
+    # fill the digits the caller left unspecified with 9s
+    return ts + pd.Timedelta(nanoseconds=10 ** (9 - digits) - 1)
+
+
+# The legacy bound format the portal used to send, e.g. "02-2024".
+MONTH_ONLY_PATTERN = re.compile(r"^(0[1-9]|1[0-2])-\d{4}$")
+
+
+def _month_to_iso(date_string: str, *, is_end: bool) -> str:
+    """Rewrite a legacy "MM-YYYY" bound as the ISO date it means.
+
+    The portal sends ISO now. Converting here keeps the one place that still
+    understands the old format at the entry, so nothing downstream has to.
+
+    :param date_string: raw bound; anything not "MM-YYYY" is returned untouched
+    :param is_end: True picks the last day of the month, False the first
+    :return: a "YYYY-MM-DD" string
+
+    Example:
+        _month_to_iso("02-2024", is_end=False) -> "2024-02-01"
+        _month_to_iso("02-2024", is_end=True) -> "2024-02-29"
+        _month_to_iso("2024-02-15", is_end=True) -> "2024-02-15"  (not MM-YYYY)
+    """
+    if not MONTH_ONLY_PATTERN.match(date_string):
+        return date_string
+
+    month = parse_date(date_string, format_to_convert="%m-%Y")
+    day = get_final_day_of_month_(month) if is_end else get_first_day_of_month(month)
+    return day.strftime(YEAR_MONTH_DAY)
+
+
+def to_utc_bounds(
     start_date_str: str, end_date_str: str
 ) -> Tuple[pd.Timestamp, pd.Timestamp]:
+    """Turn the request's raw date strings into the UTC bounds the subset uses.
+
+    This is the entry point: everything downstream works in UTC-aware
+    pd.Timestamp, never in strings.
+
+    :param start_date_str: raw start bound, ISO-8601 or legacy "MM-YYYY"
+    :param end_date_str: raw end bound, same formats
+    :return: (start, end) UTC timestamps; the end is widened to the last
+        nanosecond of the precision it was given, so a plain date still means
+        that whole day
+
+    Example:
+        to_utc_bounds("2024-01-15", "2024-01-15")
+        -> ("2024-01-15 00:00:00+00:00", "2024-01-15 23:59:59.999999999+00:00")
     """
-    Supply the day to the start and end date strings. if the date string is not in this format: "MM-yyyy", don't use this function
+    start_date_str = _month_to_iso(start_date_str, is_end=False)
+    end_date_str = _month_to_iso(end_date_str, is_end=True)
 
-    Args:
-        start_date_str (str): Start date string.
-        end_date_str (str): End date string.
-
-    Returns:
-        Tuple[datetime, datetime]: Start and end dates as datetime objects.
-    """
-    pattern = r"^(0[1-9]|1[0-2])-\d{4}$"
-    if (not re.match(pattern, start_date_str)) or (not re.match(pattern, end_date_str)):
-        # currently, if no date ranges selected in frontend, the start_date & end_date will be in this format: "yyyy-MM-dd",
-        # so for this case, we don't need to supply the day
-        return parse_date(start_date_str), end_of_day_nano(parse_date(end_date_str))
-
-    start_date = parse_date(start_date_str, format_to_convert="%m-%Y")
-    end_date = parse_date(end_date_str, format_to_convert="%m-%Y")
-
-    start_date = get_first_day_of_month(start_date)
-    end_date = end_of_day_nano(get_final_day_of_month_(end_date))
-
-    return start_date, end_date
+    return (
+        parse_date(start_date_str),
+        end_of_specified_precision(end_date_str, parse_date(end_date_str)),
+    )
 
 
 def split_date_range(
@@ -393,37 +508,63 @@ def split_date_range(
     end_date: pd.Timestamp,
     month_count_per_job: int,
 ) -> dict:
+    """Group a date range into the windows one Batch array job hands its children.
+
+    The last window is kept even when it holds fewer months than asked for. If
+    the whole range has fewer months than month_count_per_job, everything
+    collapses into a single window at key 0.
+
+    :param start_date: start of the range
+    :param end_date: end of the range
+    :param month_count_per_job: how many calendar months one child job covers
+    :return: {child job index: [start string, end string]}, naive UTC strings
+
+    Example:
+        split_date_range("2024-01-01", "2024-02-29", month_count_per_job=1)
+        -> {0: ["2024-01-01 00:00:00.000000000", "2024-01-31 23:59:59.999999999"],
+            1: ["2024-02-01 00:00:00.000000000", "2024-02-29 00:00:00.000000000"]}
+           The last window ends at the requested end, not at end of month.
+    """
     date_ranges = {}
     index = 0
 
     months: list[dict] = get_monthly_utc_date_range_array_from_(start_date, end_date)
 
+    def as_param(window: list[dict]) -> list[str]:
+        # AWS Batch job parameters are strings, so the bounds cross to the child
+        # job as text; naive UTC with nanoseconds is what parse_date reads back.
+        return [
+            to_naive_utc_string(window[0]["start_date"]),
+            to_naive_utc_string(window[-1]["end_date"]),
+        ]
+
     # Special case, if your split is too high and cannot be split we just return the start end date
     if len(months) < month_count_per_job:
-        date_ranges[0] = [
-            f"{months[0]['start_date'].strftime('%Y-%m-%d %H:%M:%S.%f')}{months[0]['start_date'].nanosecond:03d}",
-            f"{months[-1]['end_date'].strftime('%Y-%m-%d %H:%M:%S.%f')}{months[-1]['end_date'].nanosecond:03d}",
-        ]
+        date_ranges[0] = as_param(months)
     else:
         for i in range(0, len(months), month_count_per_job):
             window = months[i : i + month_count_per_job]
+            date_ranges[index] = as_param(window)
             if len(window) < month_count_per_job:
-                date_ranges[index] = [
-                    f"{window[0]['start_date'].strftime('%Y-%m-%d %H:%M:%S.%f')}{window[0]['start_date'].nanosecond:03d}",
-                    f"{window[-1]['end_date'].strftime('%Y-%m-%d %H:%M:%S.%f')}{window[-1]['end_date'].nanosecond:03d}",
-                ]
-                break  # Skip incomplete windows
-
-            date_ranges[index] = [
-                f"{window[0]['start_date'].strftime('%Y-%m-%d %H:%M:%S.%f')}{window[0]['start_date'].nanosecond:03d}",
-                f"{window[-1]['end_date'].strftime('%Y-%m-%d %H:%M:%S.%f')}{window[-1]['end_date'].nanosecond:03d}",
-            ]
+                # already stored above; a short window can only be the last one
+                break
             index = index + 1
 
     return date_ranges
 
 
 def time_it(func):
+    """Log how long the wrapped function took to run.
+
+    :param func: function to time; sync and async are both supported
+    :return: the wrapped function, returning whatever `func` returns
+
+    Example:
+        @time_it
+        def add(a, b): ...
+        add(1, 2) -> returns 3 and logs "[add] took 0.000002 seconds."
+    """
+
     @wraps(func)
     async def async_wrapper(*args, **kwargs):
         start = time.perf_counter()

--- a/data_access_service/utils/email_templates/form_subsetting_divs.py
+++ b/data_access_service/utils/email_templates/form_subsetting_divs.py
@@ -1,7 +1,8 @@
 import logging
 import pandas
 from datetime import datetime
-from data_access_service.models.subset_request import NON_SPECIFIED
+from data_access_service.core.constants import NON_SPECIFIED, UNIX_EPOCH_UTC
+from data_access_service.utils.date_time_utils import ensure_timezone
 from data_access_service.utils.email_templates.subsetting_geometry import (
     split_bboxes_and_polygons,
 )
@@ -27,6 +28,24 @@ def _to_display_date(value):
         return value
 
 
+def _is_default_range(start_date, end_date) -> bool:
+    """True when the range is the portal's "no date filter" default - the epoch
+    through today - which must not render as if the user had chosen it.
+
+    Compares instants, not strings: the defaults are written with full
+    nanosecond precision, so "1970-01-01" and "1970-01-01T00:00:00Z" are the
+    same bound and both have to be recognised here.
+    """
+    try:
+        start = ensure_timezone(pandas.Timestamp(start_date))
+        end = ensure_timezone(pandas.Timestamp(end_date))
+    except (ValueError, TypeError):
+        return False
+    return (
+        start <= UNIX_EPOCH_UTC and end.date() >= pandas.Timestamp.now(tz="UTC").date()
+    )
+
+
 def form_subsetting_divs(start_date, end_date, multi_polygon):
     """Form subsetting section with date range, bounding boxes and polygons"""
 
@@ -38,12 +57,8 @@ def form_subsetting_divs(start_date, end_date, multi_polygon):
 
         # Check if not NON_SPECIFIED and not default values
         is_non_specified = start_str == NON_SPECIFIED or end_str == NON_SPECIFIED
-        is_default = (
-            start_str == "1970-01-01"
-            and end_str == pandas.Timestamp.today().strftime("%Y-%m-%d").lower()
-        )
 
-        has_dates = not is_non_specified and not is_default
+        has_dates = not is_non_specified and not _is_default_range(start_date, end_date)
 
     # Split the spatial selection into bounding boxes (<=4 vertices) and freeform polygons (>4).
     # Never let a malformed geometry break the whole email - omit the spatial section instead.

--- a/data_access_service/utils/subset_request_resolver.py
+++ b/data_access_service/utils/subset_request_resolver.py
@@ -16,11 +16,9 @@ from data_access_service.core.constants import UNIX_EPOCH_UTC
 from data_access_service.models.bounding_box import BoundingBox
 from data_access_service.models.subset_request import SubsetRequest
 from data_access_service.utils.date_time_utils import (
-    end_of_day_nano,
     ensure_timezone,
     resolve_non_specified_dates,
-    start_of_day_nano,
-    supply_day_with_nano_precision,
+    to_utc_bounds,
 )
 from data_access_service.utils.multi_polygon_helper import MultiPolygonHelper
 
@@ -143,15 +141,15 @@ def resolve_date_range(
 
     Steps:
     1. resolve "non-specified" dates to defaults
-    2. parse with day + nano precision supplied (end date becomes the final
-       nanosecond)
+    2. parse into UTC bounds (the end date becomes the final nanosecond of the
+       precision it was given)
     3. when api and keys are given, trim to the union temporal extent of the
        keys - (None, None) means the request is entirely outside it
 
     Without api/keys it is a pure string-to-Timestamp conversion (steps 1-2).
     """
     start_str, end_str = resolve_non_specified_dates(start_date_str, end_date_str)
-    start_date, end_date = supply_day_with_nano_precision(start_str, end_str)
+    start_date, end_date = to_utc_bounds(start_str, end_str)
 
     if api is not None and keys:
         start_date, end_date = trim_date_range_for_keys(
@@ -266,6 +264,7 @@ def trim_date_range_for_keys(
     if requested_end_date > max_date_of_keys:
         trimmed_end_date = max_date_of_keys
 
-    # keep full-day semantics: floor the start and ceil the end to the
-    # first/final nanosecond of their days
-    return start_of_day_nano(trimmed_start_date), end_of_day_nano(trimmed_end_date)
+    # Returned as-is. Rounding out to whole days here would throw away a time
+    # the caller asked for, and would be redundant anyway: get_temporal_extent
+    # already reports its bounds day-aligned, so a clamped bound is aligned too.
+    return trimmed_start_date, trimmed_end_date

--- a/tests/batch/subsetting/helpers/test_request_helper.py
+++ b/tests/batch/subsetting/helpers/test_request_helper.py
@@ -10,7 +10,7 @@ from data_access_service.batch.subsetting.helpers.request_helper import (
 from data_access_service.utils.subset_request_resolver import (
     trim_date_range_for_keys,
 )
-from data_access_service.utils.date_time_utils import supply_day_with_nano_precision
+from data_access_service.utils.date_time_utils import to_utc_bounds
 
 _GLOBAL_POLYGON = (
     '{"type":"MultiPolygon","coordinates":'
@@ -101,7 +101,7 @@ class TestTrimDateRangeForKeys(unittest.TestCase):
         requested_start = "1970-01-01"
         requested_end = pd.Timestamp.now().strftime("%Y-%m-%d")
 
-        requested_start, requested_end = supply_day_with_nano_precision(
+        requested_start, requested_end = to_utc_bounds(
             requested_start,
             requested_end,
         )
@@ -165,7 +165,7 @@ class TestTrimDateRangeForKeys(unittest.TestCase):
         requested_start = "1970-01-01"
         requested_end = "1971-01-01"
 
-        requested_start, requested_end = supply_day_with_nano_precision(
+        requested_start, requested_end = to_utc_bounds(
             requested_start,
             requested_end,
         )

--- a/tests/batch/subsetting/test_init.py
+++ b/tests/batch/subsetting/test_init.py
@@ -141,9 +141,21 @@ class TestInit(TestWithS3):
                 with patch.object(AWSHelper, "submit_a_job") as submit_a_job:
                     get_month_count_per_job.return_value = 1200  # Set a very high month count to ensure no splitting occurs
                     # Mock the get_temporal_extent method to return a fixed value
+                    # Shaped like the real API.get_temporal_extent, which
+                    # reports its bounds day-aligned: start at the first
+                    # nanosecond of the day, end at the last.
                     get_temporal_extent.return_value = (
                         pd.Timestamp(year=1970, month=1, day=1),
-                        pd.Timestamp(year=2024, month=12, day=31),
+                        pd.Timestamp(
+                            year=2024,
+                            month=12,
+                            day=31,
+                            hour=23,
+                            minute=59,
+                            second=59,
+                            microsecond=999999,
+                            nanosecond=999,
+                        ),
                     )
 
                     submit_a_job.return_value = "test-job-id-returned"

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -13,10 +13,7 @@ from aodn_cloud_optimised.lib.DataQuery import ParquetDataSource
 
 from data_access_service import API
 from data_access_service.core.api import BaseAPI
-from data_access_service.core.routes.helpers import (
-    _generate_partial_json_array,
-    _response_json,
-)
+from data_access_service.core.routes.helpers import _generate_partial_json_array
 
 
 class TestApi(unittest.TestCase):
@@ -205,7 +202,7 @@ class TestApi(unittest.TestCase):
 
         # Parse the JSON result but need to get it back to object so that compare
         # of null in json string is converted back to None in object
-        parsed_result = json.loads(_response_json(result, compress=False).body)
+        parsed_result = json.loads(json.dumps([x for x in result]))
 
         # Expected output
         expected = [

--- a/tests/core/test_routes_utc_dates.py
+++ b/tests/core/test_routes_utc_dates.py
@@ -1,0 +1,118 @@
+"""Route-level date handling for issue 9061.
+
+Two things the pinned process timezone cannot fix: a default worked out once at
+import time, and an output format that does not say "UTC" in a way JS parses by
+spec.
+"""
+
+import inspect
+import json
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+from data_access_service.config.config import Config
+from data_access_service.core.routes import data as data_routes
+from data_access_service.core.routes.auth import api_key_auth
+from data_access_service.core.routes.helpers import (
+    require_api_ready,
+    resolve_end_date_param,
+)
+from data_access_service.server import app
+
+BASE = Config.BASE_URL
+
+
+@pytest.fixture
+def api():
+    """A ready API instance, with auth and readiness checks bypassed."""
+    mock = MagicMock()
+    app.dependency_overrides[require_api_ready] = lambda: mock
+    app.dependency_overrides[api_key_auth] = lambda: "test-key"
+    yield mock
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client():
+    with patch("data_access_service.server.API"):
+        with TestClient(app) as c:
+            yield c
+
+
+class TestEndDateDefaultIsPerRequest:
+    """The default used to be datetime.now() in the signature, so it was frozen
+    at import: a server up for a week answered with the date it started on. It
+    also had no fractional seconds, so verify_datatime_param rejected it and
+    omitting end_date returned 400."""
+
+    def test_omitting_end_date_is_accepted(self, api, client):
+        api.has_data.return_value = True
+        response = client.get(f"{BASE}/data/some-uuid/some-key/has_data")
+        assert response.status_code == 200
+
+    def test_omitted_end_date_resolves_to_now(self, api, client):
+        api.has_data.return_value = True
+        before = pd.Timestamp.now(tz="UTC")
+        client.get(f"{BASE}/data/some-uuid/some-key/has_data")
+        after = pd.Timestamp.now(tz="UTC")
+
+        end_date = api.has_data.call_args.args[3]
+        assert end_date.tz is not None
+        assert before <= end_date <= after
+
+    def test_no_end_date_default_is_computed_at_import(self):
+        """Guards the regression: anything evaluated in the signature is
+        evaluated once, when the module is imported."""
+        for handler in (data_routes.has_data, data_routes.get_data):
+            default = inspect.signature(handler).parameters["end_date"].default
+            # Query(default=...) wraps the value, a bare default does not
+            assert getattr(default, "default", default) is None
+
+    def test_explicit_end_date_is_still_validated(self, api, client):
+        # nanosecond precision is required for end_date
+        response = client.get(
+            f"{BASE}/data/some-uuid/some-key/has_data",
+            params={"end_date": "2024-01-15"},
+        )
+        assert response.status_code == 400
+
+    def test_resolve_end_date_param_follows_the_clock(self):
+        first = resolve_end_date_param(None)
+        second = resolve_end_date_param(None)
+        assert first.tz is not None
+        assert second >= first
+
+    def test_resolve_end_date_param_accepts_an_offset(self):
+        result = resolve_end_date_param("2024-01-15T10:00:00.123456789+10:00")
+        assert result == pd.Timestamp("2024-01-15T00:00:00.123456789Z")
+
+
+class TestTemporalExtentSendsZ:
+    """strftime("%z") wrote "+0000" - no colon, so not one of the two forms the
+    ECMAScript date-time format defines."""
+
+    def test_renders_z(self, api, client):
+        api.get_temporal_extent.return_value = (
+            pd.Timestamp("2024-01-15T00:00:00"),
+            pd.Timestamp("2024-06-30T23:59:59"),
+        )
+        response = client.get(f"{BASE}/data/some-uuid/some-key/temporal_extent")
+
+        assert response.status_code == 200
+        assert json.loads(response.content) == [
+            {"start_date": "2024-01-15T00:00:00Z", "end_date": "2024-06-30T23:59:59Z"}
+        ]
+
+    def test_a_non_utc_extent_is_converted(self, api, client):
+        api.get_temporal_extent.return_value = (
+            pd.Timestamp("2024-01-15T10:00:00+10:00"),
+            pd.Timestamp("2024-06-30T10:00:00+10:00"),
+        )
+        response = client.get(f"{BASE}/data/some-uuid/some-key/temporal_extent")
+
+        assert json.loads(response.content) == [
+            {"start_date": "2024-01-15T00:00:00Z", "end_date": "2024-06-30T00:00:00Z"}
+        ]

--- a/tests/utils/test_date_time_uils.py
+++ b/tests/utils/test_date_time_uils.py
@@ -15,9 +15,9 @@ from data_access_service.batch.subsetting.helpers.parquet_date_ranges import (
 )
 from data_access_service.utils.date_time_utils import (
     MIN_DATE,
-    end_of_day_nano,
+    _end_of_day_nano,
     parse_date,
-    get_final_day_of_month_,
+    _get_final_day_of_month,
     get_monthly_utc_date_range_array_from_,
     ensure_timezone,
     split_date_range,
@@ -102,7 +102,7 @@ class TestDateTimeUtils(unittest.TestCase):
             nanosecond=999,
             tz=pytz.UTC,
         )
-        target_date = get_final_day_of_month_(date)
+        target_date = _get_final_day_of_month(date)
         self.assertEqual(target_date, expected_date)
 
     def test_get_monthly_date_range_array_from_(self):
@@ -1327,7 +1327,7 @@ class TestDateTimeUtils(unittest.TestCase):
         self.assertEqual(start, MIN_DATE)
         # now(tz="UTC"), not today(): today() reads the host clock and names the
         # wrong calendar day on any runner not pinned to UTC.
-        self.assertEqual(parse_date(end), end_of_day_nano(pd.Timestamp.now(tz="UTC")))
+        self.assertEqual(parse_date(end), _end_of_day_nano(pd.Timestamp.now(tz="UTC")))
 
     def test_resolve_non_specified_dates_passthrough(self):
         # Concrete values are returned unchanged.
@@ -1339,7 +1339,7 @@ class TestDateTimeUtils(unittest.TestCase):
         # Only the open bound is replaced; the concrete one is left alone.
         start, end = resolve_non_specified_dates("2008-08-05", NON_SPECIFIED)
         self.assertEqual(start, "2008-08-05")
-        self.assertEqual(parse_date(end), end_of_day_nano(pd.Timestamp.now(tz="UTC")))
+        self.assertEqual(parse_date(end), _end_of_day_nano(pd.Timestamp.now(tz="UTC")))
 
     def test_to_naive_utc_none_passes_through(self):
         self.assertIsNone(to_naive_utc(None))

--- a/tests/utils/test_date_time_uils.py
+++ b/tests/utils/test_date_time_uils.py
@@ -14,17 +14,15 @@ from data_access_service.batch.subsetting.helpers.parquet_date_ranges import (
     trim_date_range,
 )
 from data_access_service.utils.date_time_utils import (
+    MIN_DATE,
+    end_of_day_nano,
     parse_date,
     get_final_day_of_month_,
-    next_month_first_day,
     get_monthly_utc_date_range_array_from_,
-    get_boundary_of_year_month,
-    transfer_date_range_into_yearmonth,
-    split_yearmonths_into_dict,
     ensure_timezone,
     split_date_range,
     split_date_range_binary,
-    supply_day_with_nano_precision,
+    to_utc_bounds,
     resolve_non_specified_dates,
     to_naive_utc,
 )
@@ -106,15 +104,6 @@ class TestDateTimeUtils(unittest.TestCase):
         )
         target_date = get_final_day_of_month_(date)
         self.assertEqual(target_date, expected_date)
-
-    def test_next_month_first_day(self):
-        date = pd.Timestamp(year=2023, month=1, day=31)
-        expected_date = pd.Timestamp(year=2023, month=2, day=1, tz=pytz.UTC)
-        self.assertEqual(next_month_first_day(date), expected_date)
-
-        date = pd.Timestamp(year=2023, month=1, day=31, tz="Asia/Tokyo")
-        expected_date = pd.Timestamp(year=2023, month=2, day=1, tz="Asia/Tokyo")
-        self.assertEqual(next_month_first_day(date), expected_date)
 
     def test_get_monthly_date_range_array_from_(self):
         """
@@ -996,96 +985,6 @@ class TestDateTimeUtils(unittest.TestCase):
             uuid="test-uuid", key="test-key"
         )
 
-    def test_get_boundary_of_year_month(self):
-        """Test the boundary of a year-month string."""
-        year_month_str = "2023-10"
-        expected_start = pd.Timestamp(
-            year=2023, month=10, day=1, hour=0, minute=0, second=0, tz=pytz.UTC
-        )
-        expected_end = pd.Timestamp(
-            year=2023,
-            month=10,
-            day=31,
-            hour=23,
-            minute=59,
-            second=59,
-            microsecond=999999,
-            nanosecond=999,
-            tz=pytz.UTC,
-        )
-
-        start_date, end_date = get_boundary_of_year_month(year_month_str)
-
-        self.assertEqual(start_date, expected_start)
-        self.assertEqual(end_date, expected_end)
-
-        year_month_str2 = "02-2023"
-        expected_start2 = pd.Timestamp(
-            year=2023, month=2, day=1, hour=0, minute=0, second=0, tz=pytz.UTC
-        )
-        expected_end2 = pd.Timestamp(
-            year=2023,
-            month=2,
-            day=28,
-            hour=23,
-            minute=59,
-            second=59,
-            microsecond=999999,
-            nanosecond=999,
-            tz=pytz.UTC,
-        )
-
-        start_date2, end_date2 = get_boundary_of_year_month(year_month_str2)
-        self.assertEqual(start_date2, expected_start2)
-        self.assertEqual(end_date2, expected_end2)
-
-    def test_transfer_date_range_into_yearmonth(self):
-        start_date = "09-2020"
-        end_date = "10-2021"
-
-        yearmonths = transfer_date_range_into_yearmonth(
-            start_date=start_date, end_date=end_date
-        )
-        expected_yearmonths = [
-            "09-2020",
-            "10-2020",
-            "11-2020",
-            "12-2020",
-            "01-2021",
-            "02-2021",
-            "03-2021",
-            "04-2021",
-            "05-2021",
-            "06-2021",
-            "07-2021",
-            "08-2021",
-            "09-2021",
-            "10-2021",
-        ]
-        self.assertEqual(yearmonths, expected_yearmonths)
-
-    def test_split_yearmonths_into_dict(self):
-        yearmonths = [
-            "2023-01",
-            "2023-02",
-            "2023-03",
-            "2023-04",
-            "2023-05",
-            "2023-06",
-            "2023-07",
-            "2023-08",
-            "2023-09",
-            "2023-10",
-        ]
-        expected_dict = {
-            0: ["2023-01", "2023-02", "2023-03"],
-            1: ["2023-04", "2023-05", "2023-06"],
-            2: ["2023-07", "2023-08", "2023-09"],
-            3: ["2023-10"],
-        }
-        result = split_yearmonths_into_dict(yearmonths, 3)
-        self.assertEqual(result, expected_dict)
-
     def test_datetime_without_timezone(self):
         # Test case: datetime without timezone should be assigned UTC
         dt = pd.Timestamp(year=2025, month=6, day=12, hour=8, minute=34)
@@ -1094,22 +993,25 @@ class TestDateTimeUtils(unittest.TestCase):
         self.assertEqual(result, datetime(2025, 6, 12, 8, 34, tzinfo=pytz.UTC))
 
     def test_datetime_with_timezone(self):
-        # Test case: datetime with timezone should remain unchanged
+        # Test case: an aware datetime is converted to UTC, same instant
         dt = pd.Timestamp(
             year=2025, month=6, day=12, hour=8, minute=34, tz="US/Pacific"
         )
         result = ensure_timezone(dt)
-        self.assertEqual(result.tzname(), "PDT")
+        self.assertEqual(result.tzname(), "UTC")
         self.assertEqual(result, dt)
+        self.assertEqual(result.hour, 15)
 
     def test_datetime_with_different_timezone(self):
-        # Test case: datetime with non-UTC timezone should remain unchanged
+        # Test case: same for a timezone ahead of UTC
         dt = pd.Timestamp(
             year=2025, month=6, day=12, hour=8, minute=34, tz="Asia/Tokyo"
         )
         result = ensure_timezone(dt)
-        self.assertEqual(result.tzname(), "JST")
+        self.assertEqual(result.tzname(), "UTC")
         self.assertEqual(result, dt)
+        # 08:34 JST is the previous day in UTC
+        self.assertEqual((result.day, result.hour), (11, 23))
 
     def test_datetime_preservation(self):
         # Test case: ensure original datetime components are preserved
@@ -1375,7 +1277,7 @@ class TestDateTimeUtils(unittest.TestCase):
             tz=pytz.UTC,
         )
         expected_tuple = (expected_start1, expected_end1)
-        result_tuple = supply_day_with_nano_precision(start_date1, end_date1)
+        result_tuple = to_utc_bounds(start_date1, end_date1)
         self.assertEqual(result_tuple, expected_tuple)
 
         # test supply day to full string
@@ -1404,7 +1306,7 @@ class TestDateTimeUtils(unittest.TestCase):
             tz=pytz.UTC,
         )
         expected_tuple2 = (expected_start2, expected_end2)
-        result_tuple2 = supply_day_with_nano_precision(start_date2, end_date2)
+        result_tuple2 = to_utc_bounds(start_date2, end_date2)
         self.assert_same_datetime(result_tuple2[0], expected_tuple2[0])
         self.assert_same_datetime(result_tuple2[1], expected_tuple2[1])
 
@@ -1420,10 +1322,12 @@ class TestDateTimeUtils(unittest.TestCase):
         self.assertEqual(dt1.tzinfo, dt2.tzinfo)
 
     def test_resolve_non_specified_dates_both_open(self):
-        # Both bounds open -> 1970-01-01 / today, matching batch init().
+        # Both bounds open -> epoch / end of today (UTC), matching batch init().
         start, end = resolve_non_specified_dates(NON_SPECIFIED, NON_SPECIFIED)
-        self.assertEqual(start, "1970-01-01")
-        self.assertEqual(end, pd.Timestamp.today().strftime("%Y-%m-%d"))
+        self.assertEqual(start, MIN_DATE)
+        # now(tz="UTC"), not today(): today() reads the host clock and names the
+        # wrong calendar day on any runner not pinned to UTC.
+        self.assertEqual(parse_date(end), end_of_day_nano(pd.Timestamp.now(tz="UTC")))
 
     def test_resolve_non_specified_dates_passthrough(self):
         # Concrete values are returned unchanged.
@@ -1435,7 +1339,7 @@ class TestDateTimeUtils(unittest.TestCase):
         # Only the open bound is replaced; the concrete one is left alone.
         start, end = resolve_non_specified_dates("2008-08-05", NON_SPECIFIED)
         self.assertEqual(start, "2008-08-05")
-        self.assertEqual(end, pd.Timestamp.today().strftime("%Y-%m-%d"))
+        self.assertEqual(parse_date(end), end_of_day_nano(pd.Timestamp.now(tz="UTC")))
 
     def test_to_naive_utc_none_passes_through(self):
         self.assertIsNone(to_naive_utc(None))

--- a/tests/utils/test_email_template.py
+++ b/tests/utils/test_email_template.py
@@ -21,7 +21,6 @@ from data_access_service.utils.email_templates.coordinate_format import (
 )
 from data_access_service.models.bounding_box import BoundingBox
 
-
 # ---------------------------------------------------------------------------
 # The user draws an area on the map; the email shows it back to them.
 #
@@ -150,6 +149,29 @@ class TestSubsettingPolygon(unittest.TestCase):
 
         self.assertIn("Polygon Selection", html)
         self.assertNotIn("Date Range", html)
+
+    def test_default_dates_are_suppressed_in_iso_form(self):
+        # resolve_non_specified_dates now writes the defaults at full precision.
+        # The check compares instants, so both spellings must be recognised;
+        # a string comparison against "1970-01-01" missed this one and the
+        # email rendered a bogus "1970 - today" range.
+        end = pandas.Timestamp.now(tz="UTC")
+        html = form_subsetting_divs(
+            "1970-01-01T00:00:00Z",
+            end.strftime("%Y-%m-%dT23:59:59.999999999+00:00"),
+            FREEFORM_POLYGON,
+        )
+
+        self.assertIn("Polygon Selection", html)
+        self.assertNotIn("Date Range", html)
+
+    def test_real_range_still_renders_in_iso_form(self):
+        # The suppression must not swallow a range the user actually chose.
+        html = form_subsetting_divs(
+            "2024-01-05T00:00:00Z", "2024-12-31T23:59:59.999999999+00:00", None
+        )
+
+        self.assertIn("Date Range", html)
 
     def test_default_dates_without_area_returns_empty(self):
         # Default dates and no spatial selection means nothing to show at all.

--- a/tests/utils/test_utc_request_dates.py
+++ b/tests/utils/test_utc_request_dates.py
@@ -1,0 +1,307 @@
+"""Dates in a request must mean UTC - issue 9061.
+
+Principle: a datetime with no offset is read as UTC; one that carries `Z` or an
+offset is converted to UTC. The process timezone is pinned to UTC as a safety
+net (see tests/test_timezone_defaults.py), but that only covers naive clock
+calls - it does not parse input, format output, or stop a value being frozen at
+import time. These are the parts it cannot reach.
+"""
+
+import pandas as pd
+import pytest
+
+from unittest.mock import MagicMock
+
+from data_access_service.core.constants import UNIX_EPOCH_UTC
+from data_access_service.models.subset_request import SubsetRequest
+from data_access_service.utils.date_time_utils import (
+    end_of_day_nano,
+    ensure_timezone,
+    parse_date,
+    has_explicit_time,
+    resolve_non_specified_dates,
+    to_utc_bounds,
+    to_naive_utc_string,
+    to_utc_iso_z,
+)
+from data_access_service.utils.subset_request_resolver import resolve_date_range
+
+
+class TestAcceptsTimezoneAwareInput:
+    """parse_date used to call tz_localize() unconditionally, which raises on an
+    already-aware value - so the ISO-8601 a JS date picker emits crashed."""
+
+    @pytest.mark.parametrize(
+        "value",
+        ["2024-01-15", "2024-01-15T00:00:00Z", "2024-01-15T10:00:00+10:00"],
+    )
+    def test_does_not_raise(self, value):
+        start, end = resolve_date_range(value, value)
+        assert start.tz is not None and end.tz is not None
+
+    def test_offset_is_converted_not_relabelled(self):
+        # 10:00+10:00 is midnight UTC, not 10:00 UTC
+        start, _ = resolve_date_range("2024-01-15T10:00:00+10:00", "2024-01-16")
+        assert start == pd.Timestamp("2024-01-15T00:00:00Z")
+
+    def test_naive_is_read_as_utc(self):
+        start, _ = resolve_date_range("2024-01-15", "2024-01-16")
+        assert start == pd.Timestamp("2024-01-15T00:00:00Z")
+
+
+class TestEndBoundCoversTheUnitItWasGivenTo:
+    """An inclusive end bound includes the whole unit the caller specified: a
+    date means that day, a whole second means that second.
+
+    The portal (aodn-portal-v2 PR #957) sends toUtcEndOfDay - which is
+    23:59:59.999 - through the format "YYYY-MM-DDTHH:mm:ss[Z]", so the
+    milliseconds never reach us. Reading 23:59:59Z literally would leave the
+    last second of the day outside this range and outside the next one.
+    """
+
+    def test_portal_end_of_day_covers_the_whole_second(self):
+        start, end = to_utc_bounds("2020-01-01T00:00:00Z", "2020-01-02T23:59:59Z")
+        assert start == pd.Timestamp("2020-01-01T00:00:00Z")
+        assert end == pd.Timestamp("2020-01-02T23:59:59.999999999Z")
+
+    def test_date_only_is_widened_to_the_whole_utc_day(self):
+        start, end = to_utc_bounds("2024-01-15", "2024-01-15")
+        assert start == pd.Timestamp("2024-01-15T00:00:00Z")
+        assert end == pd.Timestamp("2024-01-15T23:59:59.999999999Z")
+
+    def test_a_mid_day_second_is_not_widened_past_that_second(self):
+        _, end = to_utc_bounds("2024-01-15", "2024-01-15T10:00:00Z")
+        assert end == pd.Timestamp("2024-01-15T10:00:00.999999999Z")
+
+    def test_milliseconds_are_widened_only_below_the_millisecond(self):
+        _, end = to_utc_bounds("2024-01-15", "2024-01-15T10:00:00.123Z")
+        assert end == pd.Timestamp("2024-01-15T10:00:00.123999999Z")
+
+    def test_full_nanosecond_precision_is_left_alone(self):
+        _, end = to_utc_bounds("2024-01-15", "2024-01-15T10:00:00.123456789Z")
+        assert end == pd.Timestamp("2024-01-15T10:00:00.123456789Z")
+
+    def test_no_gap_between_consecutive_day_ranges(self):
+        """The end of one day and the start of the next must leave nothing
+        between them, or that sliver is undownloadable."""
+        _, day1_end = to_utc_bounds("2024-01-15T00:00:00Z", "2024-01-15T23:59:59Z")
+        day2_start, _ = to_utc_bounds("2024-01-16T00:00:00Z", "2024-01-16T23:59:59Z")
+        assert day2_start - day1_end == pd.Timedelta(nanoseconds=1)
+
+    def test_month_input_still_covers_the_whole_month(self):
+        start, end = to_utc_bounds("02-2024", "02-2024")
+        assert start == pd.Timestamp("2024-02-01T00:00:00Z")
+        assert end == pd.Timestamp("2024-02-29T23:59:59.999999999Z")
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("2024-01-15", False),
+            ("02-2024", False),
+            ("2024-01-15T10:00:00Z", True),
+            ("2024-01-15 10:00:00", True),
+        ],
+    )
+    def test_has_explicit_time(self, value, expected):
+        assert has_explicit_time(value) is expected
+
+
+class TestCustomFormatKeepsNanoseconds:
+    """pd.to_datetime parses all 9 digits of a "%f" fraction. The manual fix-up
+    that used to add the last 3 back was written for datetime.strptime, which
+    stops at microseconds - on pandas it added them twice."""
+
+    def test_nine_digit_fraction_is_parsed_exactly(self):
+        result = parse_date(
+            "2024-01-15 23:59:59.123456789",
+            format_to_convert="%Y-%m-%d %H:%M:%S.%f",
+        )
+        assert result == pd.Timestamp("2024-01-15 23:59:59.123456789", tz="UTC")
+        assert result.nanosecond == 789
+
+    def test_six_digit_fraction_is_unchanged(self):
+        result = parse_date(
+            "2024-01-15 23:59:59.123456",
+            format_to_convert="%Y-%m-%d %H:%M:%S.%f",
+        )
+        assert result == pd.Timestamp("2024-01-15 23:59:59.123456", tz="UTC")
+
+
+class TestEnsureTimezoneNormalisesToUtc:
+    def test_naive_is_assumed_utc(self):
+        assert ensure_timezone(pd.Timestamp("2024-01-15 10:00")).tzname() == "UTC"
+
+    def test_aware_keeps_the_instant_but_loses_the_offset(self):
+        result = ensure_timezone(pd.Timestamp("2024-01-15T10:00:00+10:00"))
+        assert result.tzname() == "UTC"
+        # the offset must be gone, or a later strftime() would render 10:00
+        assert result.strftime("%Y-%m-%dT%H:%M:%S") == "2024-01-15T00:00:00"
+
+
+class TestApiOutputFormat:
+    """%z writes "+0000" with no colon, which the ECMAScript date-time format
+    does not define. Browsers accept it; the spec does not."""
+
+    def test_utc_renders_with_z(self):
+        assert to_utc_iso_z(pd.Timestamp("2024-01-15T00:00:00Z")) == (
+            "2024-01-15T00:00:00Z"
+        )
+
+    def test_naive_is_treated_as_utc(self):
+        assert to_utc_iso_z(pd.Timestamp("2024-01-15T00:00:00")) == (
+            "2024-01-15T00:00:00Z"
+        )
+
+    def test_offset_is_converted_before_rendering(self):
+        assert to_utc_iso_z(pd.Timestamp("2024-01-15T10:00:00+10:00")) == (
+            "2024-01-15T00:00:00Z"
+        )
+
+
+class TestParquetFilterKeepsTheWholeRange:
+    """The row-count filter used to format the range as "%Y-%m-%d". The library
+    compares against pd.to_datetime(end_str), so the end became midnight: a
+    one-day range collapsed to one instant, counted 0 rows, and was dropped."""
+
+    def test_end_of_day_survives_formatting(self):
+        _, end = resolve_date_range("2024-01-15", "2024-01-15")
+        assert to_naive_utc_string(end) == "2024-01-15 23:59:59.999999999"
+        # what the library will actually compare the TIME column against
+        assert pd.to_datetime(to_naive_utc_string(end)) == pd.Timestamp(
+            "2024-01-15 23:59:59.999999999"
+        )
+
+    def test_string_is_naive_because_the_time_column_is(self):
+        _, end = resolve_date_range("2024-01-15", "2024-01-15")
+        assert pd.to_datetime(to_naive_utc_string(end)).tz is None
+
+    def test_offset_is_converted_to_utc_not_dropped(self):
+        assert to_naive_utc_string(pd.Timestamp("2024-01-15T10:00:00+10:00")) == (
+            "2024-01-15 00:00:00.000000000"
+        )
+
+    def test_two_halves_of_one_day_stay_distinct(self):
+        # a binary split lands inside one day on large datasets; truncating to
+        # the calendar day made both halves the same string
+        left_end = pd.Timestamp("2024-01-15 11:59:59.999999999Z")
+        right_start = pd.Timestamp("2024-01-15 12:00:00Z")
+        assert to_naive_utc_string(left_end) != to_naive_utc_string(right_start)
+
+
+class TestOpenEndDate:
+    def test_open_end_date_uses_the_utc_date(self):
+        start, end = resolve_non_specified_dates("non-specified", "non-specified")
+        assert parse_date(start) == UNIX_EPOCH_UTC
+        assert parse_date(end) == end_of_day_nano(pd.Timestamp.now(tz="UTC"))
+
+    def test_open_end_date_is_already_the_end_of_the_day(self):
+        """The default must not rely on end_of_specified_precision running
+        downstream to become the end of the day - it says so itself."""
+        _, end = resolve_non_specified_dates("non-specified", "non-specified")
+        assert parse_date(end).strftime("%H:%M:%S") == "23:59:59"
+        assert parse_date(end).nanosecond == 999
+
+
+class TestTrimKeepsRequestedPrecision:
+    """The extent trim must narrow a range, never widen it back to whole days.
+
+    It used to end with start_of_day_nano()/end_of_day_nano(), so any request
+    that named a time lost it the moment the dataset reported an extent - the
+    exact precision this module exists to preserve.
+    """
+
+    @staticmethod
+    def _api_with_extent(start: str, end: str):
+        api = MagicMock()
+        api.get_temporal_extent.return_value = (
+            pd.Timestamp(start),
+            pd.Timestamp(end),
+        )
+        return api
+
+    def test_explicit_times_survive_the_trim(self):
+        api = self._api_with_extent("2020-01-01T00:00:00Z", "2030-01-01T00:00:00Z")
+        start, end = resolve_date_range(
+            "2024-01-15T10:00:00Z",
+            "2024-01-15T12:00:00Z",
+            api=api,
+            uuid="u",
+            keys=["k"],
+        )
+        assert start == pd.Timestamp("2024-01-15T10:00:00Z")
+        assert end == pd.Timestamp("2024-01-15T12:00:00.999999999Z")
+
+    def test_trim_matches_the_untrimmed_parse(self):
+        # A request wholly inside the extent must resolve to exactly what it
+        # resolves to with no extent to trim against.
+        api = self._api_with_extent("2020-01-01T00:00:00Z", "2030-01-01T00:00:00Z")
+        trimmed = resolve_date_range(
+            "2024-01-15T10:30:00Z",
+            "2024-01-16T18:45:00Z",
+            api=api,
+            uuid="u",
+            keys=["k"],
+        )
+        assert trimmed == resolve_date_range(
+            "2024-01-15T10:30:00Z", "2024-01-16T18:45:00Z"
+        )
+
+    def test_date_only_request_still_covers_the_whole_day(self):
+        # Dropping the widening must not regress the common case: a bare date
+        # still means that entire day.
+        api = self._api_with_extent("2020-01-01T00:00:00Z", "2030-01-01T00:00:00Z")
+        start, end = resolve_date_range(
+            "2024-01-15", "2024-01-15", api=api, uuid="u", keys=["k"]
+        )
+        assert start == pd.Timestamp("2024-01-15T00:00:00Z")
+        assert end == pd.Timestamp("2024-01-15T23:59:59.999999999Z")
+
+    def test_out_of_range_bound_is_still_clamped_to_the_extent(self):
+        api = self._api_with_extent(
+            "2024-01-10T00:00:00Z", "2024-01-20T23:59:59.999999999Z"
+        )
+        start, end = resolve_date_range(
+            "2020-01-01", "2029-12-31", api=api, uuid="u", keys=["k"]
+        )
+        assert start == pd.Timestamp("2024-01-10T00:00:00Z")
+        assert end == pd.Timestamp("2024-01-20T23:59:59.999999999Z")
+
+
+class TestMonthOnlyBoundsHandledAtEntry:
+    def test_month_only_expands_to_the_whole_month(self):
+        start, end = to_utc_bounds("02-2024", "02-2024")
+        assert start == pd.Timestamp("2024-02-01T00:00:00Z")
+        assert end == pd.Timestamp("2024-02-29T23:59:59.999999999Z")  # leap year
+
+    def test_mixed_month_only_and_iso_bounds(self):
+        # The legacy check is per-bound now, so one side being ISO no longer
+        # makes the other side fall through unexpanded.
+        start, end = to_utc_bounds("02-2024", "2024-03-15T06:00:00Z")
+        assert start == pd.Timestamp("2024-02-01T00:00:00Z")
+        assert end == pd.Timestamp("2024-03-15T06:00:00.999999999Z")
+
+
+class TestSubsetRequestDateValidation:
+    def test_mixed_naive_and_aware_bounds_do_not_crash(self):
+        # pd.Timestamp() left one bound naive and the other aware, and the
+        # start > end check then raised TypeError before any resolving ran.
+        request = SubsetRequest(
+            uuid="u",
+            keys=["k"],
+            start_date="2024-01-15",
+            end_date="2024-01-16T00:00:00Z",
+            recipient="a@b.com",
+            output_format="netcdf",
+        )
+        assert request.start_date == "2024-01-15"
+
+    def test_start_after_end_is_still_rejected(self):
+        with pytest.raises(ValueError, match="must be on or before"):
+            SubsetRequest(
+                uuid="u",
+                keys=["k"],
+                start_date="2024-01-17",
+                end_date="2024-01-16T00:00:00Z",
+                recipient="a@b.com",
+                output_format="netcdf",
+            )

--- a/tests/utils/test_utc_request_dates.py
+++ b/tests/utils/test_utc_request_dates.py
@@ -7,6 +7,7 @@ calls - it does not parse input, format output, or stop a value being frozen at
 import time. These are the parts it cannot reach.
 """
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -15,10 +16,10 @@ from unittest.mock import MagicMock
 from data_access_service.core.constants import UNIX_EPOCH_UTC
 from data_access_service.models.subset_request import SubsetRequest
 from data_access_service.utils.date_time_utils import (
-    end_of_day_nano,
+    _end_of_day_nano,
     ensure_timezone,
     parse_date,
-    has_explicit_time,
+    _has_explicit_time,
     resolve_non_specified_dates,
     to_utc_bounds,
     to_naive_utc_string,
@@ -103,7 +104,7 @@ class TestEndBoundCoversTheUnitItWasGivenTo:
         ],
     )
     def test_has_explicit_time(self, value, expected):
-        assert has_explicit_time(value) is expected
+        assert _has_explicit_time(value) is expected
 
 
 class TestCustomFormatKeepsNanoseconds:
@@ -157,6 +158,19 @@ class TestApiOutputFormat:
             "2024-01-15T00:00:00Z"
         )
 
+    def test_sub_second_digits_are_kept(self):
+        """Truncating an end bound would drop the tail of the last second, the
+        same data loss _end_of_specified_precision exists to prevent."""
+        assert to_utc_iso_z(pd.Timestamp("2024-01-15T00:00:00.123456Z")) == (
+            "2024-01-15T00:00:00.123456Z"
+        )
+
+    def test_numpy_datetime64_is_accepted(self):
+        """The zarr time coordinate hands out datetime64, not pd.Timestamp."""
+        assert to_utc_iso_z(np.datetime64("2024-01-15T00:00:00")) == (
+            "2024-01-15T00:00:00Z"
+        )
+
 
 class TestParquetFilterKeepsTheWholeRange:
     """The row-count filter used to format the range as "%Y-%m-%d". The library
@@ -192,10 +206,10 @@ class TestOpenEndDate:
     def test_open_end_date_uses_the_utc_date(self):
         start, end = resolve_non_specified_dates("non-specified", "non-specified")
         assert parse_date(start) == UNIX_EPOCH_UTC
-        assert parse_date(end) == end_of_day_nano(pd.Timestamp.now(tz="UTC"))
+        assert parse_date(end) == _end_of_day_nano(pd.Timestamp.now(tz="UTC"))
 
     def test_open_end_date_is_already_the_end_of_the_day(self):
-        """The default must not rely on end_of_specified_precision running
+        """The default must not rely on _end_of_specified_precision running
         downstream to become the end of the day - it says so itself."""
         _, end = resolve_non_specified_dates("non-specified", "non-specified")
         assert parse_date(end).strftime("%H:%M:%S") == "23:59:59"


### PR DESCRIPTION
## Changes (mainly datetime utils)

| Area | Before | After | Example |
| --- | --- | --- | --- |
| Parse a date string | `pd.Timestamp()` / `tz_localize()` everywhere | one `parse_date()`, always UTC-aware | `"2024-01-15T10:00:00+10:00"` -> `2024-01-15 00:00:00+00:00` |
| Request entry point | `supply_day_with_nano_precision()`, always widened to the whole day | `to_utc_bounds()`, widens only to the unit the user gave | `"2024-01-15"` -> whole day; `"...T10:00:00Z"` -> `...10:00:00.999999999` |
| Parquet filter strings | `strftime("%Y-%m-%d")` — the end meant midnight | `to_naive_utc_string()` keeps time + nanoseconds | `2024-01-15 23:59:59.999999999` |
| API response dates | `%z` -> `+0000` | `to_utc_iso_z()` -> `Z` | `2024-01-15T00:00:00Z` |
| `Z` formatters | three copies: `to_utc_iso_z`, the tiler's, and `sites/geojson.py`'s | one implementation, the other two delegate | all three now return the same string for the same instant |
| `date_time_utils` surface | every helper public | only helpers used outside the module stay public | helpers used only inside are `_`-prefixed now |
| Default `end_date` in routes | computed once at import time | `resolve_end_date_param()` per request | server up 10 days still answers with today |
| Trim to dataset extent | rounded to whole days | keeps the clamped bounds | a requested time is no longer thrown away |
| Custom-format parsing | manual nanosecond "fix" added digits twice | removed, `pd.to_datetime` already keeps 9 digits | `.123456789` stayed `.123456789` (was `.123457578`) |
| Email "no date filter" check | compared strings | compares instants | `1970-01-01T00:00:00Z` also counts as the default |
| `NON_SPECIFIED` | in `models/subset_request.py` | moved to `core/constants.py`, re-exported | no change for callers |
